### PR TITLE
Rename ttl to got and extend it

### DIFF
--- a/mcc/got/cmd/delete.go
+++ b/mcc/got/cmd/delete.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// deleteCmd represents the delete command
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: Work your own magic here
+		fmt.Println("delete called")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(deleteCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// deleteCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// deleteCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/mcc/got/cmd/list.go
+++ b/mcc/got/cmd/list.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: Work your own magic here
+		fmt.Println("list called")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(listCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// listCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// listCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/mcc/got/cmd/root.go
+++ b/mcc/got/cmd/root.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgFile string
+
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "got",
+	Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	//	Run: func(cmd *cobra.Command, args []string) { },
+}
+
+// Execute adds all child commands to the root command sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	// Here you will define your flags and configuration settings.
+	// Cobra supports Persistent Flags, which, if defined here,
+	// will be global for your application.
+
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.got.yaml)")
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	RootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" { // enable ability to specify config file via flag
+		viper.SetConfigFile(cfgFile)
+	}
+
+	viper.SetConfigName(".got")  // name of config file (without extension)
+	viper.AddConfigPath("$HOME") // adding home directory as first search path
+	viper.AutomaticEnv()         // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+}

--- a/mcc/got/cmd/ttl.go
+++ b/mcc/got/cmd/ttl.go
@@ -1,24 +1,104 @@
 package cmd
 
 import (
-	"fmt"
+	"log"
 
+	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/spf13/cobra"
+
+	"github.com/Devex/spaceflight/mcc/got/got"
 )
+
+var dryrun, exclude, wait, filterByName, filterByType bool
+var zoneName string
+var ttl int64
 
 // ttlCmd represents the ttl command
 var ttlCmd = &cobra.Command{
-	Use:   "ttl",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Use:   "ttl [flags] [filters ...]",
+	Short: "Modify Time To Live of a set of records in a DNS zone",
+	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		// TODO: Work your own magic here
-		fmt.Println("ttl called")
+		svc := got.Init()
+		if len(zoneName) <= 0 {
+			log.Fatal("No zone name specified")
+		}
+		zoneID := got.GetZoneID(zoneName, svc)
+
+		list := got.GetResourceRecordSet(zoneID, svc)
+		// Filter list in between
+		if exclude && filterByType {
+			list = got.FilterResourceRecords(
+				list,
+				args,
+				func(
+					elem *route53.ResourceRecordSet,
+					filter string,
+				) *route53.ResourceRecordSet {
+					if *elem.Type != filter {
+						return elem
+					}
+					return nil
+				},
+			)
+		} else if exclude && filterByName {
+			list = got.FilterResourceRecords(
+				list,
+				args,
+				func(
+					elem *route53.ResourceRecordSet,
+					filter string,
+				) *route53.ResourceRecordSet {
+					if *elem.Name != filter {
+						return elem
+					}
+					return nil
+				},
+			)
+		} else if filterByType {
+			list = got.FilterResourceRecords(
+				list,
+				args,
+				func(
+					elem *route53.ResourceRecordSet,
+					filter string,
+				) *route53.ResourceRecordSet {
+					if *elem.Type == filter {
+						return elem
+					}
+					return nil
+				},
+			)
+		} else if filterByName {
+			list = got.FilterResourceRecords(
+				list,
+				args,
+				func(
+					elem *route53.ResourceRecordSet,
+					filter string,
+				) *route53.ResourceRecordSet {
+					if *elem.Name == filter {
+						return elem
+					}
+					return nil
+				},
+			)
+		}
+		changeResponse, err := got.UpsertResourceRecordSetTTL(
+			list,
+			ttl,
+			&zoneID,
+			svc,
+		)
+		if err != nil {
+			log.Panic(err.Error())
+		}
+		if wait && !dryrun {
+			got.WaitForChangeToComplete(
+				changeResponse.ChangeInfo,
+				svc,
+			)
+		}
 	},
 }
 
@@ -30,6 +110,55 @@ func init() {
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
 	// ttlCmd.PersistentFlags().String("foo", "", "A help for foo")
+	ttlCmd.PersistentFlags().BoolVarP(
+		&dryrun,
+		"dryrun",
+		"",
+		false,
+		"Don't really do anything",
+	)
+	ttlCmd.PersistentFlags().BoolVarP(
+		&exclude,
+		"exclude",
+		"",
+		false,
+		"Exclude records matching list",
+	)
+	ttlCmd.PersistentFlags().BoolVarP(
+		&wait,
+		"wait",
+		"",
+		false,
+		"Don't return until operation is completed",
+	)
+	ttlCmd.PersistentFlags().StringVarP(
+		&zoneName,
+		"zone",
+		"",
+		"",
+		"Name of the zone to work on.",
+	)
+	ttlCmd.PersistentFlags().Int64VarP(
+		&ttl,
+		"ttl",
+		"",
+		30,
+		"New TTL value",
+	)
+	ttlCmd.PersistentFlags().BoolVarP(
+		&filterByName,
+		"name",
+		"n",
+		false,
+		"Filters are to be used as names",
+	)
+	ttlCmd.PersistentFlags().BoolVarP(
+		&filterByType,
+		"type",
+		"t",
+		false,
+		"Filters are to be used as types",
+	)
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:

--- a/mcc/got/cmd/ttl.go
+++ b/mcc/got/cmd/ttl.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// ttlCmd represents the ttl command
+var ttlCmd = &cobra.Command{
+	Use:   "ttl",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: Work your own magic here
+		fmt.Println("ttl called")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(ttlCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// ttlCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// ttlCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/mcc/got/cmd/upsert.go
+++ b/mcc/got/cmd/upsert.go
@@ -1,24 +1,44 @@
 package cmd
 
 import (
-	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
+
+	"github.com/Devex/spaceflight/mcc/got/got"
 )
+
+var name, typ string
 
 // upsertCmd represents the upsert command
 var upsertCmd = &cobra.Command{
 	Use:   "upsert",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "upsert [flags] <destination>",
+	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		// TODO: Work your own magic here
-		fmt.Println("upsert called")
+		svc := got.Init()
+		if len(zoneName) <= 0 {
+			log.Fatal("No zone name specified")
+		}
+		if len(name) <= 0 {
+			log.Fatal("No record name specified")
+		}
+		if len(typ) <= 0 {
+			log.Fatal("No record type specified")
+		}
+		if len(args) <= 0 {
+			log.Fatal("No destination specified")
+		}
+		zoneid := got.GetZoneID(zoneName, svc)
+		list := got.NewResourceRecordList(args)
+		changes := got.UpsertChangeListNames(list, ttl, name, typ)
+		if !dryrun {
+			res, err := got.ApplyChanges(changes, &zoneid, svc)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
+			log.Println(res)
+		}
 	},
 }
 
@@ -30,6 +50,55 @@ func init() {
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
 	// upsertCmd.PersistentFlags().String("foo", "", "A help for foo")
+	upsertCmd.PersistentFlags().BoolVarP(
+		&dryrun,
+		"dryrun",
+		"",
+		false,
+		"Don't really do anything",
+	)
+	upsertCmd.PersistentFlags().BoolVarP(
+		&exclude,
+		"exclude",
+		"",
+		false,
+		"Exclude records matching list",
+	)
+	upsertCmd.PersistentFlags().BoolVarP(
+		&wait,
+		"wait",
+		"",
+		false,
+		"Don't return until operation is completed",
+	)
+	upsertCmd.PersistentFlags().StringVarP(
+		&zoneName,
+		"zone",
+		"",
+		"",
+		"Name of the zone to work on.",
+	)
+	upsertCmd.PersistentFlags().Int64VarP(
+		&ttl,
+		"ttl",
+		"",
+		30,
+		"New UPSERT value",
+	)
+	upsertCmd.PersistentFlags().StringVarP(
+		&name,
+		"name",
+		"",
+		"",
+		"Name of the record to upsert.",
+	)
+	upsertCmd.PersistentFlags().StringVarP(
+		&typ,
+		"type",
+		"",
+		"",
+		"Type of the record to upsert.",
+	)
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:

--- a/mcc/got/cmd/upsert.go
+++ b/mcc/got/cmd/upsert.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// upsertCmd represents the upsert command
+var upsertCmd = &cobra.Command{
+	Use:   "upsert",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: Work your own magic here
+		fmt.Println("upsert called")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(upsertCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// upsertCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// upsertCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/mcc/got/got/got.go
+++ b/mcc/got/got/got.go
@@ -1,0 +1,258 @@
+package got
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53/route53iface"
+)
+
+// Verbose flag
+var Verbose bool
+
+// Dryrun flag
+var Dryrun bool
+
+// Filter type for generic filtering
+type Filter []string
+
+// String interface for Filter
+func (f *Filter) String() string {
+	return fmt.Sprint(*f)
+}
+
+// Set so flag can initialize flags of type Filter
+func (f *Filter) Set(value string) error {
+	for _, val := range strings.Split(value, ",") {
+		*f = append(*f, val)
+	}
+	return nil
+}
+
+// Init initializes conections to Route53
+func Init() *route53.Route53 {
+	sess, err := session.NewSession()
+	if err != nil {
+		log.Panicf("Failed to create session: %s", err)
+	}
+	return route53.New(sess)
+}
+
+// GetResourceRecordSet returns a slice containing all responses for specified
+// query. It may issue more than one request as each returns a fixed amount of
+// entries at most.
+func GetResourceRecordSet(
+	zoneID string,
+	svc route53iface.Route53API,
+) (resourceRecordSet []*route53.ResourceRecordSet) {
+	params := &route53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	}
+	for respIsTruncated := true; respIsTruncated; {
+		if Verbose {
+			fmt.Printf("Query params: %s\n", params)
+		}
+		resp, err := svc.ListResourceRecordSets(params)
+		if err != nil {
+			panic(err)
+		}
+		if *resp.IsTruncated {
+			params.StartRecordName = resp.NextRecordName
+			params.StartRecordType = resp.NextRecordType
+		}
+		respIsTruncated = *resp.IsTruncated
+
+		// Iterate over all entries and add changes to change_slice
+		for _, val := range resp.ResourceRecordSets {
+			resourceRecordSet = append(resourceRecordSet, val)
+		}
+	}
+	return
+}
+
+// upsertChangeList iterates over a list of records and returns a list of
+// Change objects of type Upsert with the specified TTL
+func upsertChangeList(
+	list []*route53.ResourceRecordSet,
+	ttl int64,
+) (res []*route53.Change) {
+	for _, val := range list {
+		*val.TTL = ttl
+		change := &route53.Change{
+			Action:            aws.String("UPSERT"),
+			ResourceRecordSet: val,
+		}
+		log.Printf(
+			"Adding %s to change list for TTL %d\n",
+			*val.Name,
+			ttl)
+		res = append(res, change)
+	}
+	return
+}
+
+// NewResourceRecordList creates a list of ResourceRecords with a ResourceRecord
+// per each string passed.
+func NewResourceRecordList(values []string) (ret []*route53.ResourceRecord) {
+	for _, val := range values {
+		ret = append(ret,
+			&route53.ResourceRecord{
+				Value: aws.String(val),
+			},
+		)
+	}
+	return
+}
+
+// UpsertChangeListNames iterates over a list of records and returns a list of
+// Change objects of type Upsert with the specified TTL
+func UpsertChangeListNames(
+	list []*route53.ResourceRecord,
+	ttl int64,
+	name string,
+	typ string,
+) (res []*route53.Change) {
+	val := &route53.ResourceRecordSet{
+		ResourceRecords: list,
+		TTL:             &ttl,
+		Type:            &typ,
+		Name:            &name,
+	}
+	change := &route53.Change{
+		Action:            aws.String("UPSERT"),
+		ResourceRecordSet: val,
+	}
+	log.Printf(
+		"Adding %s to change list for TTL %d\n",
+		*val.Name,
+		ttl)
+	res = append(res, change)
+	return
+}
+
+// WaitForChangeToComplete waits until the ChangeInfo described by the argument is completed.
+func WaitForChangeToComplete(
+	changeInfo *route53.ChangeInfo,
+	svc *route53.Route53,
+) {
+	getChangeInput := route53.GetChangeInput{Id: changeInfo.Id}
+	getChangeOutput, err := svc.GetChange(&getChangeInput)
+	if err != nil {
+		log.Panic(err.Error())
+	}
+	for *getChangeOutput.ChangeInfo.Status != route53.ChangeStatusInsync {
+		time.Sleep(1)
+		getChangeOutput, err = svc.GetChange(&getChangeInput)
+		if err != nil {
+			log.Panic(err.Error())
+		}
+	}
+	if Verbose {
+		fmt.Println(getChangeOutput.ChangeInfo)
+	}
+	log.Println("All changes applied")
+}
+
+// UpsertResourceRecordSetTTL performs the request to change the TTL of the list
+// of records.
+func UpsertResourceRecordSetTTL(
+	list []*route53.ResourceRecordSet,
+	ttl int64,
+	zoneID *string,
+	svc *route53.Route53,
+) (
+	changeResponse *route53.ChangeResourceRecordSetsOutput,
+	err error,
+) {
+	if len(list) <= 0 {
+		log.Fatal("No records to process.")
+	}
+	changeSlice := upsertChangeList(list, ttl)
+
+	// Create batch with all jobs
+	changeBatch := &route53.ChangeBatch{
+		Changes: changeSlice,
+	}
+	if err := changeBatch.Validate(); err != nil {
+		log.Panic(err.Error())
+	}
+
+	changeRRSInput := &route53.ChangeResourceRecordSetsInput{
+		ChangeBatch:  changeBatch,
+		HostedZoneId: zoneID,
+	}
+
+	if err := changeRRSInput.Validate(); err != nil {
+		log.Panic(err.Error())
+	}
+	// Submit batch changes
+	if !Dryrun {
+		changeResponse, err = svc.ChangeResourceRecordSets(changeRRSInput)
+	}
+	if err != nil {
+		log.Panic(err)
+	}
+	if Verbose && !Dryrun {
+		fmt.Println(changeResponse.ChangeInfo)
+	}
+	return
+}
+
+// PrintRecords prints all records in a zone using the API's built-in method
+// ListResourceRecordSets.
+func PrintRecords(
+	p *route53.ListResourceRecordSetsOutput,
+	last bool,
+) (shouldContinue bool) {
+	shouldContinue = *p.IsTruncated
+	for idx, val := range p.ResourceRecordSets {
+		fmt.Println(idx, *val)
+	}
+	return
+}
+
+// FilterResourceRecords returns a slice containing only the entries that
+// pass the check performed by the function argument
+func FilterResourceRecords(
+	l []*route53.ResourceRecordSet,
+	f []string,
+	p func(*route53.ResourceRecordSet, string,
+	) *route53.ResourceRecordSet,
+) (result []*route53.ResourceRecordSet) {
+	for _, elem := range l {
+		for _, filter := range f {
+			res := p(elem, filter)
+			if res != nil {
+				result = append(result, res)
+			}
+		}
+	}
+	return
+}
+
+// GetZoneID returns a string containing the ZoneID for use in further API
+// actions
+func GetZoneID(zoneName string, svc route53iface.Route53API) (zoneID string) {
+	params := &route53.ListHostedZonesByNameInput{
+		DNSName:  aws.String(zoneName),
+		MaxItems: aws.String("100"),
+	}
+	resp, err := svc.ListHostedZonesByName(params)
+	if err != nil {
+		log.Println(err.Error())
+	}
+	if len(resp.HostedZones) == 0 {
+		log.Fatalf("No results for zone %s. Exiting.\n", zoneName)
+	}
+	zoneID = *resp.HostedZones[0].Id
+	if Verbose {
+		// Pretty-print the response data.
+		fmt.Println(zoneID)
+	}
+	return
+}

--- a/mcc/got/got/got_test.go
+++ b/mcc/got/got/got_test.go
@@ -1,0 +1,316 @@
+package got
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/route53/route53iface"
+)
+
+var one = "one.example.com"
+var two = "two.example.com"
+var hundred = "100"
+var zoneName = "test"
+var A = "A"
+var AAAA = "AAAA"
+var fals = false
+var duration1 int64 = 1
+var duration5 int64 = 5
+
+var onerecordA = &route53.ResourceRecordSet{
+	Name: &one,
+	Type: &A,
+	TTL:  &duration1,
+}
+
+var tworecordAAAA = &route53.ResourceRecordSet{
+	Name: &two,
+	Type: &AAAA,
+	TTL:  &duration5,
+}
+
+var ResourceRecordSetList = []*route53.ResourceRecordSet{
+	onerecordA,
+	tworecordAAAA,
+}
+
+var hostedZone = route53.HostedZone{
+	CallerReference: &hundred,
+}
+
+// Define a mock struct to be used in unit tests.
+type mockRoute53Client struct {
+	route53iface.Route53API
+}
+
+func (m *mockRoute53Client) ListResourceRecordSets(
+	params *route53.ListResourceRecordSetsInput,
+) (out *route53.ListResourceRecordSetsOutput, err error) {
+	out = &route53.ListResourceRecordSetsOutput{
+		IsTruncated:        &fals,
+		MaxItems:           &hundred,
+		ResourceRecordSets: ResourceRecordSetList,
+	}
+	return
+}
+
+func (m *mockRoute53Client) ListHostedZonesByName(
+	params *route53.ListHostedZonesByNameInput,
+) (out *route53.ListHostedZonesByNameOutput, err error) {
+	hostedZone.Id = &zoneName
+	hostedZone.Name = &zoneName
+	out = &route53.ListHostedZonesByNameOutput{
+		IsTruncated: &fals,
+		MaxItems:    &hundred,
+		HostedZones: []*route53.HostedZone{&hostedZone},
+	}
+	return
+}
+
+var rrstest = []struct {
+	rrsl       []*route53.ResourceRecordSet
+	typeFilter []string
+	nameFilter []string
+	out        []*route53.ResourceRecordSet
+}{
+	{
+		ResourceRecordSetList,
+		[]string{"A"},
+		[]string{"one.example.com"},
+		[]*route53.ResourceRecordSet{
+			onerecordA,
+		},
+	},
+	{
+		ResourceRecordSetList,
+		[]string{"AAAA"},
+		[]string{"two.example.com"},
+		[]*route53.ResourceRecordSet{
+			tworecordAAAA,
+		},
+	},
+	{
+		ResourceRecordSetList,
+		[]string{"MX"},
+		[]string{"non-existent"},
+		[]*route53.ResourceRecordSet{},
+	},
+	{
+		ResourceRecordSetList,
+		[]string{"TXT"},
+		[]string{"non-existent"},
+		[]*route53.ResourceRecordSet{},
+	},
+	{
+		ResourceRecordSetList,
+		[]string{
+			"A",
+			"AAAA",
+		},
+		[]string{"one.example.com", "two.example.com"},
+		[]*route53.ResourceRecordSet{
+			onerecordA,
+			tworecordAAAA,
+		},
+	},
+}
+
+func TestFilterResourceRecords(t *testing.T) {
+	for _, tt := range rrstest {
+		t.Run(
+			strings.Join(tt.typeFilter, ","),
+			func(t *testing.T) {
+				fn := func(elem *route53.ResourceRecordSet, filter string) *route53.ResourceRecordSet {
+					if *elem.Type == filter {
+						return elem
+					}
+					return nil
+				}
+				r := FilterResourceRecords(
+					tt.rrsl,
+					tt.typeFilter,
+					fn,
+				)
+				if len(r) != len(tt.out) {
+					t.Error("Result has different length than expected")
+				}
+				for index, value := range r {
+					if tt.out[index] != value {
+						t.Error("Results don't match as expected")
+					}
+				}
+			},
+		)
+		t.Run(
+			strings.Join(tt.nameFilter, ","),
+			func(t *testing.T) {
+				fn := func(elem *route53.ResourceRecordSet, filter string) *route53.ResourceRecordSet {
+					if *elem.Name == filter {
+						return elem
+					}
+					return nil
+				}
+				r := FilterResourceRecords(
+					tt.rrsl,
+					tt.nameFilter,
+					fn,
+				)
+				if len(r) != len(tt.out) {
+					t.Error("Result has different length than expected")
+				}
+				for index, value := range r {
+					if tt.out[index] != value {
+						t.Error("Results don't match as expected")
+					}
+				}
+			},
+		)
+	}
+}
+
+var ucltest = []struct {
+	original []*route53.ResourceRecordSet
+	ttl      int64
+}{
+	{
+		ResourceRecordSetList,
+		60,
+	},
+	{
+		ResourceRecordSetList,
+		300,
+	},
+}
+
+func TestUpsertChangeList(t *testing.T) {
+	for _, tt := range ucltest {
+		for _, change := range upsertChangeList(tt.original, tt.ttl) {
+			if *change.ResourceRecordSet.TTL != tt.ttl {
+				t.Error("TTL doesn't match")
+			}
+		}
+	}
+}
+
+var fstest = []string{
+	"",
+	"a,b",
+	"a,,a,,c,,",
+}
+
+func TestFilterSet(t *testing.T) {
+	for _, s := range fstest {
+		t.Run(s, func(t *testing.T) {
+			var f Filter
+			_ = f.Set(s)
+			j := strings.Join(f, ",")
+			if s != j {
+				t.Error(j, " doesn't match")
+			}
+		})
+	}
+}
+
+var grrstest = []string{
+	"test",
+}
+
+func TestGetResourceRecordSet(t *testing.T) {
+	mockSvc := &mockRoute53Client{}
+	for _, s := range grrstest {
+		t.Run(s, func(t *testing.T) {
+			out := GetResourceRecordSet(s, mockSvc)
+			if len(out) != len(ResourceRecordSetList) {
+				t.Error("Response doesn't match")
+			}
+			for i, val := range ResourceRecordSetList {
+				if out[i] != val {
+					t.Error("Response doesn't match")
+				}
+			}
+		})
+	}
+}
+
+var gzitest = []string{
+	"test",
+}
+
+func TestGetZoneID(t *testing.T) {
+	mockSvc := &mockRoute53Client{}
+	for _, s := range grrstest {
+		t.Run(s, func(t *testing.T) {
+			out := GetZoneID(s, mockSvc)
+			if out != s {
+				t.Error("Response doesn't match")
+			}
+		})
+	}
+}
+
+var rrltest = []struct {
+	in  []string
+	out []*route53.ResourceRecord
+}{
+	{
+		[]string{
+			one,
+		},
+		[]*route53.ResourceRecord{
+			&route53.ResourceRecord{
+				Value: &one,
+			},
+		},
+	},
+	{
+		[]string{
+			two,
+		},
+		[]*route53.ResourceRecord{
+			&route53.ResourceRecord{
+				Value: &two,
+			},
+		},
+	},
+	{
+		[]string{
+			one,
+			two,
+		},
+		[]*route53.ResourceRecord{
+			&route53.ResourceRecord{
+				Value: &one,
+			},
+			&route53.ResourceRecord{
+				Value: &two,
+			},
+		},
+	},
+}
+
+func TestNewResourceRecordList(t *testing.T) {
+	for _, tt := range rrltest {
+		t.Run(strings.Join(tt.in, ";"), func(t *testing.T) {
+			out := NewResourceRecordList(tt.in)
+			if len(tt.in) != len(out) {
+				t.Error(
+					"Erroneous amount of responses."+
+						" Expected %d, received %d.",
+					len(tt.in),
+					len(out),
+				)
+			}
+			for i, v := range out {
+				if *v.Value != *tt.out[i].Value {
+					t.Error(
+						"Erroneous response."+
+							" Expected %s, received %s.",
+						*tt.out[i].Value,
+						*v,
+					)
+				}
+			}
+		})
+	}
+}

--- a/mcc/got/got/got_test.go
+++ b/mcc/got/got/got_test.go
@@ -3,6 +3,7 @@ package got
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
@@ -10,6 +11,7 @@ import (
 
 var one = "one.example.com"
 var two = "two.example.com"
+var awsCname = "ec2-1-2-3-4.compute-1.amazonaws.com"
 var hundred = "100"
 var zoneName = "test"
 var A = "A"
@@ -17,6 +19,7 @@ var AAAA = "AAAA"
 var fals = false
 var duration1 int64 = 1
 var duration5 int64 = 5
+var now = time.Now()
 
 var onerecordA = &route53.ResourceRecordSet{
 	Name: &one,
@@ -65,6 +68,19 @@ func (m *mockRoute53Client) ListHostedZonesByName(
 		MaxItems:    &hundred,
 		HostedZones: []*route53.HostedZone{&hostedZone},
 	}
+	return
+}
+
+func (m *mockRoute53Client) ChangeResourceRecordSets(
+	params *route53.ChangeResourceRecordSetsInput,
+) (out *route53.ChangeResourceRecordSetsOutput, err error) {
+	out = &route53.ChangeResourceRecordSetsOutput{
+		ChangeInfo: &route53.ChangeInfo{
+			Id:     params.HostedZoneId,
+			Status: pstr("PENDING"),
+		},
+	}
+
 	return
 }
 
@@ -287,6 +303,16 @@ var rrltest = []struct {
 			},
 		},
 	},
+	{
+		[]string{
+			awsCname,
+		},
+		[]*route53.ResourceRecord{
+			&route53.ResourceRecord{
+				Value: &awsCname,
+			},
+		},
+	},
 }
 
 func TestNewResourceRecordList(t *testing.T) {
@@ -310,6 +336,71 @@ func TestNewResourceRecordList(t *testing.T) {
 						*v,
 					)
 				}
+			}
+		})
+	}
+}
+
+func pstr(str string) *string {
+	return &str
+}
+
+var actest = []struct {
+	input struct {
+		changes []*route53.Change
+		zoneid  string
+	}
+	output struct {
+		out *route53.ChangeResourceRecordSetsOutput
+		err error
+	}
+}{
+	{
+		struct {
+			changes []*route53.Change
+			zoneid  string
+		}{
+			[]*route53.Change{
+				&route53.Change{
+					Action:            pstr("UPSERT"),
+					ResourceRecordSet: onerecordA,
+				},
+			},
+			"test1",
+		},
+		struct {
+			out *route53.ChangeResourceRecordSetsOutput
+			err error
+		}{
+			&route53.ChangeResourceRecordSetsOutput{
+				ChangeInfo: &route53.ChangeInfo{
+					Id: pstr("test1"),
+					// Possible values: PENDING | INSYNC
+					Status: pstr("PENDING"),
+					// It's a *time.Time
+					SubmittedAt: &now,
+				},
+			},
+			nil,
+		},
+	},
+}
+
+func TestApplyChanges(t *testing.T) {
+	mockSvc := &mockRoute53Client{}
+	for _, tt := range actest {
+		t.Run(tt.input.zoneid, func(t *testing.T) {
+			out, err := ApplyChanges(
+				tt.input.changes,
+				&tt.input.zoneid,
+				mockSvc,
+			)
+			if out == nil {
+				t.Error("Returned nil")
+			} else if *out.ChangeInfo.Id != *tt.output.out.ChangeInfo.Id ||
+				*out.ChangeInfo.Status != *tt.output.out.ChangeInfo.Status ||
+				err != tt.output.err {
+				t.Error("Unexpected outcome")
 			}
 		})
 	}

--- a/mcc/got/main.go
+++ b/mcc/got/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/Devex/spaceflight/mcc/got/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
While automating procedures we noticed some tools were lacking related functionality for our needs. In the case of ttl, it lacked the ability to change other parameters of a DNS entry though the basic mechanism was already there.

While expanding its functionality it was appropriate to rename the tool so now it's called (Lieber)got: https://en.wikipedia.org/wiki/Seymour_Liebergot