### PR TITLE
Add proper regexp validation to CIDRs

### DIFF
--- a/mcc/capcom/capcom/capcom.go
+++ b/mcc/capcom/capcom/capcom.go
@@ -3,6 +3,7 @@ package capcom
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -45,13 +46,22 @@ func BuildIPPermission(
 	perm.FromPort = &port
 	perm.ToPort = &port
 	perm.IpProtocol = &proto
+	m, err := regexp.MatchString(
+		"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]).){3}"+
+			"([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])"+
+			"(/([0-9]|[1-2][0-9]|3[0-2]))$",
+		origin,
+	)
+	if err != nil {
+		log.Panic(err.Error())
+	}
 	if strings.HasPrefix(origin, "sg-") {
 		perm.UserIdGroupPairs = []*ec2.UserIdGroupPair{
 			{
 				GroupId: &origin,
 			},
 		}
-	} else if strings.HasSuffix(origin, "/32") {
+	} else if m {
 		perm.IpRanges = []*ec2.IpRange{
 			{
 				CidrIp: &origin,

--- a/mcc/capcom/capcom/capcom_test.go
+++ b/mcc/capcom/capcom/capcom_test.go
@@ -87,7 +87,7 @@ var atsgtable = []struct {
 	err         error
 }{
 	{
-		origin:      "/32",
+		origin:      "1.2.3.4/32",
 		proto:       "tcp",
 		port:        int64(0),
 		destination: "sg-",
@@ -101,7 +101,7 @@ var atsgtable = []struct {
 		err:         nil,
 	},
 	{
-		origin:      "/32",
+		origin:      "1.2.3.4/32",
 		proto:       "udp",
 		port:        int64(0),
 		destination: "sg-",


### PR DESCRIPTION
Added form validation to user supplied IPs in CIDR notation. Regexp extracted from http://blog.markhatton.co.uk/2011/03/15/regular-expressions-for-ip-addresses-cidr-ranges-and-hostnames/ on 2017/02/20