### PR TITLE
Groundwork for Modifying JSON

### DIFF
--- a/mcc/fido/cmd/json.go
+++ b/mcc/fido/cmd/json.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
+
+	"github.com/Devex/spaceflight/mcc/fido/fido"
 )
 
 // jsonCmd represents the json command
@@ -12,7 +16,25 @@ var jsonCmd = &cobra.Command{
 	Short: "Modify contents of supplied JSON file",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("json called")
+		customJSON, err := fido.ReadFromPipe()
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		// Convert JSON into struct
+		data := new(interface{})
+		err = json.Unmarshal([]byte(customJSON), data)
+		if err != nil {
+			log.Panic(err)
+		}
+
+		// Convert struct into JSON
+		out, err := json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			log.Panic(err)
+		}
+		fmt.Print(string(out))
+
 	},
 }
 

--- a/mcc/fido/cmd/push.go
+++ b/mcc/fido/cmd/push.go
@@ -1,10 +1,7 @@
 package cmd
 
 import (
-	"bufio"
-	"io"
 	"log"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -19,32 +16,10 @@ var pushCmd = &cobra.Command{
 	Short: "Upload CustomJSON to stack",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		nBytes, nChunks := int64(0), int64(0)
-		r := bufio.NewReader(os.Stdin)
-		buf := make([]byte, 0, 4*1024)
-		customJSON := ""
-		for {
-			n, err := r.Read(buf[:cap(buf)])
-			buf = buf[:n]
-			if n == 0 {
-				if err == nil {
-					continue
-				}
-				if err == io.EOF {
-					break
-				}
-				log.Fatal(err)
-			}
-			nChunks++
-			nBytes += int64(len(buf))
-			customJSON += string(buf)
-			if err != nil && err != io.EOF {
-				log.Fatal(err)
-			}
-
-			log.Println("Bytes:", nBytes, "Chunks:", nChunks)
+		customJSON, err := fido.ReadFromPipe()
+		if err != nil {
+			log.Fatal(err.Error())
 		}
-
 		svc := fido.Init()
 		sID, err := fido.GetStackID(svc, name)
 		if err != nil {

--- a/mcc/fido/fido/fido.go
+++ b/mcc/fido/fido/fido.go
@@ -1,7 +1,11 @@
 package fido
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"log"
+	"os"
 	"strings"
 )
 
@@ -74,3 +78,33 @@ func (s ListStringEntry) Key() string { return s.key }
 
 // Value returns the value as a string
 func (s ListStringEntry) Value() string { return strings.Join(s.value, s.Separator) }
+
+// ReadFromPipe returns a string containing stdin contents
+func ReadFromPipe() (string, error) {
+	nBytes, nChunks := int64(0), int64(0)
+	r := bufio.NewReader(os.Stdin)
+	buf := make([]byte, 0, 4*1024)
+	out := ""
+	for {
+		n, err := r.Read(buf[:cap(buf)])
+		buf = buf[:n]
+		if n == 0 {
+			if err == nil {
+				continue
+			}
+			if err == io.EOF {
+				break
+			}
+			log.Fatal(err)
+		}
+		nChunks++
+		nBytes += int64(len(buf))
+		out += string(buf)
+		if err != nil && err != io.EOF {
+			return out, err
+		}
+
+		log.Println("Bytes:", nBytes, "Chunks:", nChunks)
+	}
+	return out, nil
+}


### PR DESCRIPTION
This lays the ground for the json subcommand to access and modify the JSON structure. This one simply converts the input json to an internal representation and back into valid JSON.