### PR TITLE
DVX-4445: Adds trek command to add entries to a Nginx map file

### DIFF
--- a/mcc/trek/cmd/add.go
+++ b/mcc/trek/cmd/add.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Devex/spaceflight/mcc/fido/fido"
+	"github.com/Devex/spaceflight/mcc/trek/trek"
+)
+
+var original, final string
+
+// addCmd represents the add command
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Adds a redirect",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		redirects, err := fido.ReadFromPipe()
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		output, err := trek.Add(redirects, original, final)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		fmt.Printf("%s", output)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(addCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	addCmd.PersistentFlags().StringVarP(
+		&original,
+		"original",
+		"",
+		"",
+		"Path or URI to redirect",
+	)
+	addCmd.PersistentFlags().StringVarP(
+		&final,
+		"final",
+		"",
+		"",
+		"Path or URI to redirect to",
+	)
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/mcc/trek/cmd/root.go
+++ b/mcc/trek/cmd/root.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var cfgFile string
+
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "trek",
+	Short: "Redirect configuration",
+	Long: `trek helps to configure redirects in Nginx redirects.map.
+Currently this tool only allows to add a line to the stream on standard input.`,
+}
+
+// Execute adds all child commands to the root command sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+}

--- a/mcc/trek/main.go
+++ b/mcc/trek/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/Devex/spaceflight/mcc/trek/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/mcc/trek/trek/trek.go
+++ b/mcc/trek/trek/trek.go
@@ -1,0 +1,14 @@
+package trek
+
+import "fmt"
+
+// Add adds a new redirect line for original to final, and returns it.
+func Add(redirects, original, final string) (resultingRedirects string, err error) {
+	if original == "" || final == "" {
+		err = fmt.Errorf("You must specify both original and final")
+		return
+	}
+	newRedirect := fmt.Sprintf("%s %s;\n", original, final)
+	resultingRedirects = fmt.Sprintf("%s%s", redirects, newRedirect)
+	return
+}

--- a/mcc/trek/trek/trek_test.go
+++ b/mcc/trek/trek/trek_test.go
@@ -1,0 +1,27 @@
+package trek
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestAdd tests adding a new redirect.
+func TestAdd(t *testing.T) {
+	redirect := "/en /;\n"
+	output, err := Add(redirect, "/en/about", "/about")
+	if output != fmt.Sprintf("%s/en/about /about;\n", redirect) && err == nil {
+		t.Errorf("Redirect for /en/about was not added:\n%s", output)
+	}
+	_, err = Add(redirect, "", "/")
+	if err == nil {
+		t.Errorf("Original lacking call should fail")
+	}
+	_, err = Add(redirect, "/en/about", "")
+	if err == nil {
+		t.Errorf("Final lacking call should fail")
+	}
+	_, err = Add(redirect, "", "")
+	if err == nil {
+		t.Errorf("Both original and final should be present")
+	}
+}


### PR DESCRIPTION
The tool `trek` will help managing some data.
Right now, it is only intended to provide a simple addition to a Nginx map file, like redirects.map.
It is intended to be used like this:
```
cat redirects.map | trek add --original /en/old --final /new > redirects1.map
```