### PR TITLE
DVX-5412: Add tool to create entries for healthchecks

### DIFF
--- a/mcc/health/cmd/create.go
+++ b/mcc/health/cmd/create.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Devex/spaceflight/mcc/health/health"
+)
+
+var apikey, endpoint, schedule, name, tags, sep string
+
+// createCmd represents the create command
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		message := make(map[string]interface{})
+		out := []string{}
+		check := health.NewCheck()
+		check.APIKey = apikey
+		if schedule != "" {
+			message["schedule"] = schedule
+			out = append(out, schedule)
+		}
+		if name != "" {
+			message["name"] = name
+			out = append(out, name)
+		}
+		if tags != "" {
+			message["tags"] = tags
+			out = append(out, tags)
+		}
+		res, err := check.Create(endpoint, message)
+		if err != nil {
+			log.Fatal(err)
+		}
+		m, err := health.ParseResponse(res.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
+		v, ok := m["update_url"].(string)
+		if !ok {
+			log.Fatal("Can't access field update_url")
+		}
+		slug := health.GetSlugFromURL(v)
+		out = append(out, slug)
+		fmt.Println(strings.Join(out, sep))
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(createCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// createCmd.PersistentFlags().String("foo", "", "A help for foo")
+	createCmd.PersistentFlags().StringVarP(
+		&apikey,
+		"apikey",
+		"",
+		"",
+		"Healthchecks.io API key",
+	)
+	createCmd.PersistentFlags().StringVarP(
+		&endpoint,
+		"api",
+		"",
+		"https://healthchecks.io/api/v1/checks/",
+		"Healthchecks.io API address",
+	)
+	createCmd.PersistentFlags().StringVarP(
+		&schedule,
+		"schedule",
+		"",
+		"",
+		"Cron-like schedule",
+	)
+	createCmd.PersistentFlags().StringVarP(
+		&name,
+		"name",
+		"",
+		"",
+		"Name identifier for the entry",
+	)
+	createCmd.PersistentFlags().StringVarP(
+		&tags,
+		"tags",
+		"",
+		"",
+		"Space separated list of tags",
+	)
+	createCmd.PersistentFlags().StringVarP(
+		&sep,
+		"separator",
+		"",
+		" ",
+		"Field separator string for output",
+	)
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// createCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/mcc/health/cmd/root.go
+++ b/mcc/health/cmd/root.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgFile string
+
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "health",
+	Short: "",
+	Long:  ``,
+}
+
+// Execute adds all child commands to the root command sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	// Here you will define your flags and configuration settings.
+	// Cobra supports Persistent Flags, which, if defined here,
+	// will be global for your application.
+
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.got.yaml)")
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	RootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" { // enable ability to specify config file via flag
+		viper.SetConfigFile(cfgFile)
+	}
+
+	viper.SetConfigName(".got")  // name of config file (without extension)
+	viper.AddConfigPath("$HOME") // adding home directory as first search path
+	viper.AutomaticEnv()         // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+}

--- a/mcc/health/health/health.go
+++ b/mcc/health/health/health.go
@@ -1,0 +1,71 @@
+package health
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// Check represents the checking service and holds service dependent
+// data
+type Check struct {
+	APIKey string
+}
+
+// Create adds a new check throuh an API call
+func (c *Check) Create(endpoint string, message map[string]interface{}) (res *http.Response, err error) {
+	// Request body
+	buf, err := json.Marshal(message)
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequest(
+		http.MethodPost,
+		endpoint,
+		bytes.NewBuffer(buf),
+	)
+	if err != nil {
+		return
+	}
+	// Set headers
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("X-Api-Key", c.APIKey)
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// GetSlugFromURL extracts the slug from any of the returned URLs
+func GetSlugFromURL(m string) (s string) {
+	s = strings.TrimPrefix(
+		m,
+		"https://healthchecks.io/api/v1/checks/",
+	)
+	s = strings.TrimPrefix(s, "https://hchk.io/")
+	s = strings.TrimSuffix(s, "/pause")
+	return
+}
+
+// ParseResponse converts the services' response body into a map
+func ParseResponse(in io.ReadCloser) (m map[string]interface{}, err error) {
+	m = make(map[string]interface{})
+	body, err := ioutil.ReadAll(in)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(body, &m)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// NewCheck creates an empty Check
+func NewCheck() *Check {
+	return &Check{}
+}

--- a/mcc/health/health/health_test.go
+++ b/mcc/health/health/health_test.go
@@ -1,0 +1,212 @@
+package health
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckCreate(t *testing.T) {
+	data := []struct {
+		name, schedule, channels, tags string
+		slug                           string
+		status                         int
+	}{
+		{
+			name:     "New check",
+			schedule: "* * * * *",
+			channels: "*",
+			tags:     "new minute alert",
+			slug:     "f618072a-7bde-4eee-af63-71a77c5723bc",
+			status:   http.StatusCreated,
+		},
+		{
+			name:     "New check",
+			schedule: "0 * * * *",
+			channels: "*",
+			tags:     "new hourly alert",
+			slug:     "f618072a-7bde-4eee-af63-71a77c5723bc",
+			status:   http.StatusCreated,
+		},
+		{
+			name:     "New check",
+			schedule: "0 * * * *",
+			tags:     "new hourly noalert",
+			slug:     "f618072a-7bde-4eee-af63-71a77c5723bc",
+			status:   http.StatusCreated,
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		// Process headers
+		if r.Header.Get("Content-Type") != "application/json" {
+			http.Error(
+				w,
+				"Undefined Content-Type",
+				http.StatusBadRequest,
+			)
+			return
+		}
+		if r.Header.Get("X-Api-Key") == "" {
+			http.Error(
+				w,
+				"Expected non-empty API Key header",
+				http.StatusUnauthorized,
+			)
+			return
+		}
+		// Process body
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(
+				w,
+				"Unexpected error reading request body",
+				http.StatusInternalServerError,
+			)
+			return
+		}
+		s := make(map[string]interface{})
+		err = json.Unmarshal(body, &s)
+		if err != nil {
+			http.Error(
+				w,
+				"Unexpected error parsing request body",
+				http.StatusInternalServerError,
+			)
+			return
+		}
+		for _, d := range data {
+			if d.tags == s["tags"] {
+				w.Header().Set(
+					"Content-Type",
+					"application/json",
+				)
+				w.WriteHeader(d.status)
+				b := map[string]interface{}{
+					"grace":      60,
+					"last_ping":  nil,
+					"n_pings":    0,
+					"name":       d.name,
+					"next_ping":  nil,
+					"pause_url":  "https://healthchecks.io/api/v1/checks/" + d.slug + "/pause",
+					"ping_url":   "https://hchk.io/" + d.slug,
+					"status":     "new",
+					"tags":       d.tags,
+					"timeout":    3600,
+					"update_url": "https://healthchecks.io/api/v1/checks/" + d.slug,
+				}
+				buf, err := json.Marshal(b)
+				if err != nil {
+					t.Error(err)
+				}
+				fmt.Fprintln(w, bytes.NewBuffer(buf))
+				return
+			}
+		}
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	for _, tt := range data {
+		check := NewCheck()
+		check.APIKey = "your-api-key"
+		message := map[string]interface{}{
+			"tags":     tt.tags,
+			"schedule": tt.schedule,
+			"name":     tt.name,
+		}
+		res, err := check.Create(server.URL, message)
+		if err != nil {
+			t.Error(err)
+		}
+		if res.StatusCode != tt.status {
+			t.Errorf(
+				"Expected status %d but received %d: %s",
+				tt.status,
+				res.StatusCode,
+				res.Status,
+			)
+		}
+		m, err := ParseResponse(res.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		if m["name"] != tt.name {
+			t.Errorf(
+				"Wrong name. Expected %s, found %s",
+				tt.name,
+				m["name"],
+			)
+		}
+		if m["tags"] != tt.tags {
+			t.Errorf(
+				"Wrong tags. Expected %s, found %s",
+				tt.tags,
+				m["tags"],
+			)
+		}
+		v, ok := m["update_url"].(string)
+		if !ok {
+			t.Errorf(
+				"Invalid field. Expected a string, received %v",
+				m["udate_url"],
+			)
+		}
+		if GetSlugFromURL(v) != tt.slug {
+			t.Errorf(
+				"Wrong slug. Expected %s, found %s",
+				tt.slug,
+				GetSlugFromURL(v),
+			)
+		}
+		if GetSlugFromURL(tt.slug) != tt.slug {
+			t.Errorf(
+				"String was modified. Expected %s but is %s",
+				tt.slug,
+				GetSlugFromURL(tt.slug),
+			)
+		}
+	}
+}
+
+func TestGetSlugFromURL(t *testing.T) {
+	data := []struct {
+		in, out string
+	}{
+		{
+			in:  "",
+			out: "",
+		},
+		{
+			in:  "https://healthchecks.io/api/v1/checks/f618072a-7bde-4eee-af63-71a77c5723bc",
+			out: "f618072a-7bde-4eee-af63-71a77c5723bc",
+		},
+		{
+			in:  "https://healthchecks.io/api/v1/checks/f618072a-7bde-4eee-af63-71a77c5723bc/pause",
+			out: "f618072a-7bde-4eee-af63-71a77c5723bc",
+		},
+		{
+			in:  "https://healthchecks.io/api/v1/checks/f618072a-7bde-4eee-af63-71a77c5723bc/pauses",
+			out: "f618072a-7bde-4eee-af63-71a77c5723bc/pauses",
+		},
+		{
+			in:  "https://hchk.io/f618072a-7bde-4eee-af63-71a77c5723bc",
+			out: "f618072a-7bde-4eee-af63-71a77c5723bc",
+		},
+	}
+	for _, tt := range data {
+		if GetSlugFromURL(tt.in) != tt.out {
+			t.Errorf(
+				"Wrong slug. Expected %s, found %s",
+				tt.out,
+				GetSlugFromURL(tt.in),
+			)
+		}
+	}
+}

--- a/mcc/health/main.go
+++ b/mcc/health/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/Devex/spaceflight/mcc/health/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
Create a tool to add healthcheck entries when creating new crons. Output is designed to be parsable by scripts to automate creation of cron_entry recipes.