### PR TITLE
Add empty ListSnapshots

### DIFF
--- a/mcc/odin/odin/snapshot_list.go
+++ b/mcc/odin/odin/snapshot_list.go
@@ -1,0 +1,18 @@
+package odin
+
+import (
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+)
+
+// ListSnapshots return a list of all DBSnapshots.
+func ListSnapshots(
+	instanceName string,
+	svc rdsiface.RDSAPI,
+) (
+	result []*rds.DBSnapshot,
+	err error,
+) {
+	result = make([]*rds.DBSnapshot, 0)
+	return
+}

--- a/mcc/odin/odin/snapshot_list_test.go
+++ b/mcc/odin/odin/snapshot_list_test.go
@@ -1,8 +1,12 @@
 package odin_test
 
 import (
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
+
+	"github.com/poka-yoke/spaceflight/mcc/odin/odin"
 )
 
 var exampleSnapshot1Type = aws.String("db.m1.medium")
@@ -16,4 +20,40 @@ var exampleSnapshot1 = &rds.DBSnapshot{
 	DBSnapshotIdentifier: exampleSnapshot1ID,
 	MasterUsername:       aws.String("owner"),
 	Status:               aws.String("available"),
+}
+
+type listSnapshotsCase struct {
+	testCase
+	name       string
+	snapshots  []*rds.DBSnapshot
+	instanceID string
+}
+
+var listSnapshotsCases = []listSnapshotsCase{
+	// No snapshots for any instance
+	{
+		testCase: testCase{
+			expected:      []*rds.DBSnapshot{},
+			expectedError: "",
+		},
+		name:       "No snapshots for any instance",
+		snapshots:  []*rds.DBSnapshot{},
+		instanceID: "",
+	},
+}
+
+func TestListSnapshots(t *testing.T) {
+	svc := newMockRDSClient()
+	for _, test := range listSnapshotsCases {
+		t.Run(
+			test.name,
+			func(t *testing.T) {
+				actual, err := odin.ListSnapshots(
+					test.instanceID,
+					svc,
+				)
+				test.check(actual, err, t)
+			},
+		)
+	}
 }


### PR DESCRIPTION
This PR sets up everything to start with TDD of listing snapshots feature:
* In `snapshot_list.go`, it defined `ListSnapshots` function, which right now just returns an empty list of RDS snapshots, and no error.
* In `snapshot_list_test.go`, It does three things:
  * First, it defines the case struct, for each tested case, embedding a `testCase`, which is another object with some helpers, like `check(actual, err, t)`.
  * Then, it creates a list of cases to test, with, by now, just one single test, which is the one when there's no snapshot for any single instance.
  * Finally, it defines the `TestListSnapshots` test functions, which tests each case in a goroutine.

I'm adding more inline comments, and replying comments.

Refs [DVX-5662](https://mydevex.atlassian.net/browse/DVX-5662)