### PR TITLE
Fix mockRDSClient.DescribeDBSnapshots list make

### DIFF
--- a/mcc/odin/odin/mock_rds_client_test.go
+++ b/mcc/odin/odin/mock_rds_client_test.go
@@ -26,7 +26,7 @@ func (m mockRDSClient) DescribeDBSnapshots(
 	if describeParams.DBInstanceIdentifier != nil {
 		snapshots = m.dbSnapshots[*describeParams.DBInstanceIdentifier]
 	} else {
-		snapshots = make([]*rds.DBSnapshot, len(m.dbSnapshots))
+		snapshots = make([]*rds.DBSnapshot, 0)
 		for _, l := range m.dbSnapshots {
 			for _, v := range l {
 				snapshots = append(snapshots, v)


### PR DESCRIPTION
I always get confused about how Go's `append` makes space in lists.