### PR TITLE
Add and use `listSnapshotsCase.loadSnapshots` to update RDS mock

### DIFF
--- a/mcc/odin/odin/snapshot_list.go
+++ b/mcc/odin/odin/snapshot_list.go
@@ -13,6 +13,11 @@ func ListSnapshots(
 	result []*rds.DBSnapshot,
 	err error,
 ) {
-	result = make([]*rds.DBSnapshot, 0)
+	input := &rds.DescribeDBSnapshotsInput{}
+	output, err := svc.DescribeDBSnapshots(input)
+	if err != nil {
+		return
+	}
+	result = output.DBSnapshots
 	return
 }

--- a/mcc/odin/odin/snapshot_list_test.go
+++ b/mcc/odin/odin/snapshot_list_test.go
@@ -64,6 +64,16 @@ var listSnapshotsCases = []listSnapshotsCase{
 		snapshots:  []*rds.DBSnapshot{},
 		instanceID: "",
 	},
+	// One instance, one snapshot
+	{
+		testCase: testCase{
+			expected:      []*rds.DBSnapshot{exampleSnapshot1},
+			expectedError: "",
+		},
+		name:       "One instance, one snapshot",
+		snapshots:  []*rds.DBSnapshot{exampleSnapshot1},
+		instanceID: "",
+	},
 }
 
 func TestListSnapshots(t *testing.T) {
@@ -72,6 +82,7 @@ func TestListSnapshots(t *testing.T) {
 		t.Run(
 			test.name,
 			func(t *testing.T) {
+				test.loadSnapshots(svc)
 				actual, err := odin.ListSnapshots(
 					test.instanceID,
 					svc,

--- a/mcc/odin/odin/snapshot_list_test.go
+++ b/mcc/odin/odin/snapshot_list_test.go
@@ -29,6 +29,30 @@ type listSnapshotsCase struct {
 	instanceID string
 }
 
+// loadSnapshots method loads `snapshots` from current test case
+// to the instance of the mocked RDSAPI, passed as argument.
+// It returns nothing.
+func (c *listSnapshotsCase) loadSnapshots(
+	svc *mockRDSClient,
+) {
+	// For each snapshot in the test case
+	for _, snapshot := range c.snapshots {
+		instanceID := snapshot.DBInstanceIdentifier
+		var instanceSnapshots []*rds.DBSnapshot
+		// if this snapshot's instance is not in the mock,
+		if snapshotList, ok := svc.dbSnapshots[*instanceID]; !ok {
+			// create the list of snapshots
+			instanceSnapshots = make([]*rds.DBSnapshot, 0)
+		} else {
+			// or get the reference to the list
+			instanceSnapshots = snapshotList
+		}
+		// append the snapshot to the instance's snapshot list
+		instanceSnapshots = append(instanceSnapshots, snapshot)
+		svc.dbSnapshots[*instanceID] = instanceSnapshots
+	}
+}
+
 var listSnapshotsCases = []listSnapshotsCase{
 	// No snapshots for any instance
 	{


### PR DESCRIPTION
Commit-based review is recommended here:
* Commit 8c6d654 adds a new method to the test case to update snapshots available.
* Commit afcf7c0 makes usage of this method, and adds a new test case with one snapshot.

Refers [DVX-5663](https://mydevex.atlassian.net/browse/DVX-5662)