### PR TITLE
Simplify mockRDSClient.DescribeDBSnapshots

### DIFF
--- a/mcc/odin/odin/mock_rds_client_test.go
+++ b/mcc/odin/odin/mock_rds_client_test.go
@@ -28,9 +28,7 @@ func (m mockRDSClient) DescribeDBSnapshots(
 	} else {
 		snapshots = make([]*rds.DBSnapshot, 0)
 		for _, l := range m.dbSnapshots {
-			for _, v := range l {
-				snapshots = append(snapshots, v)
-			}
+			snapshots = append(snapshots, l...)
 		}
 	}
 	result = &rds.DescribeDBSnapshotsOutput{


### PR DESCRIPTION
Nested for in mockRDSClient.DescribeDBSnapshots has been removed
by using `...` in the append, which extends the list.

Refs [DVX-5662|https://mydevex.atlassian.net/browse/DVX-5662]