### PR TITLE
Add SnapshotCreationTime to snapshot examples

### DIFF
--- a/mcc/odin/odin/snapshot_list_test.go
+++ b/mcc/odin/odin/snapshot_list_test.go
@@ -2,6 +2,7 @@ package odin_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
@@ -9,11 +10,25 @@ import (
 	"github.com/poka-yoke/spaceflight/mcc/odin/odin"
 )
 
+const (
+	RFC8601 = "2006-01-02T15:04:05-07:00"
+)
+
 var exampleSnapshot1Type = aws.String("db.m1.medium")
 var exampleSnapshot1DBID = aws.String("production-rds")
 var exampleSnapshot1ID = aws.String("rds:production-2015-06-11")
+var exampleSnapshot1Time = "2015-06-11T22:00:00+00:00"
 var exampleSnapshot2DBID = aws.String("develop-rds")
 var exampleSnapshot2ID = aws.String("rds:develop-2016-06-11")
+var exampleSnapshot2Time = "2016-06-11T22:00:00+00:00"
+
+func getTime(original string) (parsed time.Time) {
+	parsed, _ = time.Parse(
+		RFC8601,
+		original,
+	)
+	return
+}
 
 var exampleSnapshot1 = &rds.DBSnapshot{
 	AllocatedStorage:     aws.Int64(10),
@@ -21,6 +36,7 @@ var exampleSnapshot1 = &rds.DBSnapshot{
 	DBInstanceIdentifier: exampleSnapshot1DBID,
 	DBSnapshotIdentifier: exampleSnapshot1ID,
 	MasterUsername:       aws.String("owner"),
+	SnapshotCreateTime:   aws.Time(getTime(exampleSnapshot1Time)),
 	Status:               aws.String("available"),
 }
 
@@ -30,6 +46,7 @@ var exampleSnapshot2 = &rds.DBSnapshot{
 	DBInstanceIdentifier: exampleSnapshot2DBID,
 	DBSnapshotIdentifier: exampleSnapshot2ID,
 	MasterUsername:       aws.String("owner"),
+	SnapshotCreateTime:   aws.Time(getTime(exampleSnapshot2Time)),
 	Status:               aws.String("available"),
 }
 


### PR DESCRIPTION
In order to test and implement snapshot list ordering,
the snapshot examples need to have the date added.

RDS API expects it to be a `*time.Time`, so I implemented
a helper function to convert the string to `time.Time`, and
used `aws.Time()` to convert it to the expected type.

Refs [DVX-5662](https://mydevex.atlassian.net/browse/DVX-5662)