### PR TITLE
Refactor to avoid random ordering in snapshots

### DIFF
--- a/mcc/odin/odin/instance_clone_test.go
+++ b/mcc/odin/odin/instance_clone_test.go
@@ -65,7 +65,7 @@ func TestCloneInstance(t *testing.T) {
 					snapshot := test.snapshot
 					id := test.snapshot.DBInstanceIdentifier
 					snapshots := []*rds.DBSnapshot{snapshot}
-					svc.dbSnapshots[*id] = snapshots
+					svc.dbInstanceSnapshots[*id] = snapshots
 				}
 				createParams := odin.CreateParams{
 					InstanceType: test.instanceType,

--- a/mcc/odin/odin/instance_restore_test.go
+++ b/mcc/odin/odin/instance_restore_test.go
@@ -78,7 +78,7 @@ func TestGetRestoreDBInput(t *testing.T) {
 					snapshot := test.snapshot
 					id := *snapshot.DBInstanceIdentifier
 					snapshots := []*rds.DBSnapshot{snapshot}
-					svc.dbSnapshots[id] = snapshots
+					svc.dbInstanceSnapshots[id] = snapshots
 				}
 				params := test.params
 				actual, err := params.GetRestoreDBInput(
@@ -147,7 +147,7 @@ func TestRestoreInstance(t *testing.T) {
 					snapshot := test.snapshot
 					id := *snapshot.DBInstanceIdentifier
 					snapshots := []*rds.DBSnapshot{snapshot}
-					svc.dbSnapshots[id] = snapshots
+					svc.dbInstanceSnapshots[id] = snapshots
 				}
 				params := odin.RestoreParams{
 					InstanceType:         test.instanceType,

--- a/mcc/odin/odin/mock_rds_client_test.go
+++ b/mcc/odin/odin/mock_rds_client_test.go
@@ -12,7 +12,8 @@ import (
 type mockRDSClient struct {
 	rdsiface.RDSAPI
 	dbInstancesEndpoints map[string]rds.Endpoint
-	dbSnapshots          map[string][]*rds.DBSnapshot
+	dbInstanceSnapshots  map[string][]*rds.DBSnapshot
+	dbSnapshots          []*rds.DBSnapshot
 }
 
 // DescribeDBSnapshots mocks rds.DescribeDBSnapshots.
@@ -24,12 +25,10 @@ func (m mockRDSClient) DescribeDBSnapshots(
 ) {
 	var snapshots []*rds.DBSnapshot
 	if describeParams.DBInstanceIdentifier != nil {
-		snapshots = m.dbSnapshots[*describeParams.DBInstanceIdentifier]
+		id := describeParams.DBInstanceIdentifier
+		snapshots = m.dbInstanceSnapshots[*id]
 	} else {
-		snapshots = make([]*rds.DBSnapshot, 0)
-		for _, l := range m.dbSnapshots {
-			snapshots = append(snapshots, l...)
-		}
+		snapshots = m.dbSnapshots
 	}
 	result = &rds.DescribeDBSnapshotsOutput{
 		DBSnapshots: snapshots,
@@ -186,6 +185,6 @@ func (m mockRDSClient) ModifyDBInstance(
 func newMockRDSClient() *mockRDSClient {
 	return &mockRDSClient{
 		dbInstancesEndpoints: map[string]rds.Endpoint{},
-		dbSnapshots:          map[string][]*rds.DBSnapshot{},
+		dbInstanceSnapshots:  map[string][]*rds.DBSnapshot{},
 	}
 }

--- a/mcc/odin/odin/odin_test.go
+++ b/mcc/odin/odin/odin_test.go
@@ -80,7 +80,7 @@ func TestGetLastSnapshot(t *testing.T) {
 			test.name,
 			func(t *testing.T) {
 				id := test.identifier
-				svc.dbSnapshots[id] = test.snapshots
+				svc.dbInstanceSnapshots[id] = test.snapshots
 				actual, err := odin.GetLastSnapshot(
 					id,
 					svc,

--- a/mcc/odin/odin/snapshot_list_test.go
+++ b/mcc/odin/odin/snapshot_list_test.go
@@ -57,31 +57,6 @@ type listSnapshotsCase struct {
 	instanceID string
 }
 
-// loadSnapshots method loads `snapshots` from current test case
-// to the instance of the mocked RDSAPI, passed as argument.
-// It returns nothing.
-func (c *listSnapshotsCase) loadSnapshots(
-	svc *mockRDSClient,
-) {
-	svc.dbSnapshots = map[string][]*rds.DBSnapshot{}
-	// For each snapshot in the test case
-	for _, snapshot := range c.snapshots {
-		instanceID := snapshot.DBInstanceIdentifier
-		var instanceSnapshots []*rds.DBSnapshot
-		// if this snapshot's instance is not in the mock,
-		if snapshotList, ok := svc.dbSnapshots[*instanceID]; !ok {
-			// create the list of snapshots
-			instanceSnapshots = make([]*rds.DBSnapshot, 0)
-		} else {
-			// or get the reference to the list
-			instanceSnapshots = snapshotList
-		}
-		// append the snapshot to the instance's snapshot list
-		instanceSnapshots = append(instanceSnapshots, snapshot)
-		svc.dbSnapshots[*instanceID] = instanceSnapshots
-	}
-}
-
 var listSnapshotsCases = []listSnapshotsCase{
 	// No snapshots for any instance
 	{
@@ -127,7 +102,7 @@ func TestListSnapshots(t *testing.T) {
 		t.Run(
 			test.name,
 			func(t *testing.T) {
-				test.loadSnapshots(svc)
+				svc.dbSnapshots = test.snapshots
 				actual, err := odin.ListSnapshots(
 					test.instanceID,
 					svc,


### PR DESCRIPTION
By using a list for the snapshots within the mock,
the random list of keys in the map is not affecting
`TestListSnapshots`.
I tested this running the test 100 times, just to be
a little bit more sure.

Refs [DVX-5662](https://mydevex.atlassian.net/browse/DVX-5662)