### PR TITLE
Order the snapshots on creation date, newer first

### DIFF
--- a/mcc/odin/odin/snapshot_list.go
+++ b/mcc/odin/odin/snapshot_list.go
@@ -1,6 +1,8 @@
 package odin
 
 import (
+	"sort"
+
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
@@ -18,6 +20,16 @@ func ListSnapshots(
 	if err != nil {
 		return
 	}
+	// Lambda function here implements reverse ordering based
+	// on snapshot's creation time, so first element is newer.
+	sort.Slice(
+		output.DBSnapshots,
+		func(i, j int) bool {
+			return output.DBSnapshots[i].SnapshotCreateTime.After(
+				*output.DBSnapshots[j].SnapshotCreateTime,
+			)
+		},
+	)
 	result = output.DBSnapshots
 	return
 }

--- a/mcc/odin/odin/snapshot_list_test.go
+++ b/mcc/odin/odin/snapshot_list_test.go
@@ -82,8 +82,8 @@ var listSnapshotsCases = []listSnapshotsCase{
 	{
 		testCase: testCase{
 			expected: []*rds.DBSnapshot{
-				exampleSnapshot1,
 				exampleSnapshot2,
+				exampleSnapshot1,
 			},
 			expectedError: "",
 		},


### PR DESCRIPTION
This uses `sort.Slice()`, from the stdlib, to sort the snapshot slice returned
according to the lambda function.

This lambda function return `true` if the `i` element is smaller than the `j`
element.

In order to hace this ordered from newer to older, this uses
`Time.After()` to compare both.

Refs [DVX-5663](https://mydevex.atlassian.net/browse/DVX-5662)