### PR TITLE
Wire the snapshot subcommand

### DIFF
--- a/mcc/odin/cmd/snapshot.go
+++ b/mcc/odin/cmd/snapshot.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// SnapshotCmd represents the snapshot super command
+var SnapshotCmd = &cobra.Command{
+	Use:   "snapshot",
+	Short: "Odin's Snapshot management",
+	Long:  `Currently, it is mostly usable for AWS RDS.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	//	Run: func(cmd *cobra.Command, args []string) { },
+}
+
+func init() {
+	RootCmd.AddCommand(SnapshotCmd)
+}

--- a/mcc/odin/odin/snapshot_list_test.go
+++ b/mcc/odin/odin/snapshot_list_test.go
@@ -74,7 +74,7 @@ var listSnapshotsCases = []listSnapshotsCase{
 			expected:      []*rds.DBSnapshot{exampleSnapshot1},
 			expectedError: "",
 		},
-		name:       "One instance, one snapshot",
+		name:       "One instance one snapshot",
 		snapshots:  []*rds.DBSnapshot{exampleSnapshot1},
 		instanceID: "",
 	},


### PR DESCRIPTION
For defining CLI options and subcommands, this is using [Cobra](github.com/spf13/cobra).
It's just defining the `snapshot` subcommand to hold space for all other 
snapshot related commands.

Refs [DVX-5662](https://mydevex.atlassian.net/browse/DVX-5662)