### PR TITLE
Wire the snapshot list subcommand

### DIFF
--- a/mcc/odin/cmd/snapshot_list.go
+++ b/mcc/odin/cmd/snapshot_list.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/poka-yoke/spaceflight/mcc/odin/odin"
+)
+
+// snapshotListCmd represents the snapshot list command
+var snapshotListCmd = &cobra.Command{
+	Use:   "list identifier",
+	Short: "Lists all snapshots",
+	Long:  `Lists all snapshots, ordered from newer to older.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			args = append(args, "")
+		}
+		svc := odin.Init()
+		snapshots, err := odin.ListSnapshots(
+			args[0],
+			svc,
+		)
+		if err != nil {
+			log.Fatalf("Error: %s", err)
+		}
+		fmt.Println(snapshots)
+	},
+}
+
+func init() {
+	SnapshotCmd.AddCommand(snapshotListCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// createCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// createCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}


### PR DESCRIPTION
This adds `list` to `snapshot` subcommand.
The logic implemented here is pretty simple.
If no argument was supplied, the first one is assumed to be empty string.
Initialize odin, and ask for snapshots on this argument.
Treats the error, if any, and prints the snapshots.

This requires #67 to be merged

Refs [DVX-5662](mydevex.atlassian.net/browse/DVX-5662)