### PR TITLE
Add `PrintSnapshots()`

### DIFF
--- a/mcc/odin/cmd/snapshot_list.go
+++ b/mcc/odin/cmd/snapshot_list.go
@@ -26,7 +26,7 @@ var snapshotListCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Error: %s", err)
 		}
-		fmt.Println(snapshots)
+		fmt.Println(odin.PrintSnapshots(snapshots))
 	},
 }
 

--- a/mcc/odin/odin/snapshot_list.go
+++ b/mcc/odin/odin/snapshot_list.go
@@ -1,11 +1,36 @@
 package odin
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
+
+const (
+	// RFC8601 is the date/time format used by AWS.
+	RFC8601 = "2006-01-02T15:04:05-07:00"
+)
+
+// PrintSnapshots return a string with the snapshot list output.
+func PrintSnapshots(snapshots []*rds.DBSnapshot) string {
+	lines := []string{}
+	for _, snapshot := range snapshots {
+		line := fmt.Sprintf(
+			"%v %v %v %v\n",
+			*snapshot.DBSnapshotIdentifier,
+			*snapshot.DBInstanceIdentifier,
+			(*snapshot.SnapshotCreateTime).Format(
+				RFC8601,
+			),
+			*snapshot.Status,
+		)
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "")
+}
 
 // ListSnapshots return a list of all DBSnapshots.
 func ListSnapshots(

--- a/mcc/odin/odin/snapshot_list_test.go
+++ b/mcc/odin/odin/snapshot_list_test.go
@@ -64,13 +64,7 @@ var exampleSnapshot2Out = fmt.Sprintf(
 	"available",
 )
 
-type printSnapshotsCase struct {
-	testCase
-	name      string
-	snapshots []*rds.DBSnapshot
-}
-
-var printSnapshotsCases = []printSnapshotsCase{
+var printSnapshotsCases = []listSnapshotsCase{
 	// No snapshots
 	{
 		testCase: testCase{

--- a/mcc/odin/odin/snapshot_list_test.go
+++ b/mcc/odin/odin/snapshot_list_test.go
@@ -1,6 +1,8 @@
 package odin_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -8,10 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 
 	"github.com/poka-yoke/spaceflight/mcc/odin/odin"
-)
-
-const (
-	RFC8601 = "2006-01-02T15:04:05-07:00"
 )
 
 var exampleSnapshot1Type = aws.String("db.m1.medium")
@@ -24,7 +22,7 @@ var exampleSnapshot2Time = "2016-06-11T22:00:00+00:00"
 
 func getTime(original string) (parsed time.Time) {
 	parsed, _ = time.Parse(
-		RFC8601,
+		odin.RFC8601,
 		original,
 	)
 	return
@@ -48,6 +46,81 @@ var exampleSnapshot2 = &rds.DBSnapshot{
 	MasterUsername:       aws.String("owner"),
 	SnapshotCreateTime:   aws.Time(getTime(exampleSnapshot2Time)),
 	Status:               aws.String("available"),
+}
+
+var exampleSnapshot1Out = fmt.Sprintf(
+	"%v %v %v %v\n",
+	*exampleSnapshot1ID,
+	*exampleSnapshot1DBID,
+	exampleSnapshot1Time,
+	"available",
+)
+
+var exampleSnapshot2Out = fmt.Sprintf(
+	"%v %v %v %v\n",
+	*exampleSnapshot2ID,
+	*exampleSnapshot2DBID,
+	exampleSnapshot2Time,
+	"available",
+)
+
+type printSnapshotsCase struct {
+	testCase
+	name      string
+	snapshots []*rds.DBSnapshot
+}
+
+var printSnapshotsCases = []printSnapshotsCase{
+	// No snapshots
+	{
+		testCase: testCase{
+			expected:      "",
+			expectedError: "",
+		},
+		name:      "No snapshots",
+		snapshots: []*rds.DBSnapshot{},
+	},
+	// One snapshot
+	{
+		testCase: testCase{
+			expected:      exampleSnapshot1Out,
+			expectedError: "",
+		},
+		name:      "One snapshot",
+		snapshots: []*rds.DBSnapshot{exampleSnapshot1},
+	},
+	// Two snapshots
+	{
+		testCase: testCase{
+			expected: strings.Join(
+				[]string{
+					exampleSnapshot2Out,
+					exampleSnapshot1Out,
+				},
+				"",
+			),
+			expectedError: "",
+		},
+		name: "Two snapshots",
+		snapshots: []*rds.DBSnapshot{
+			exampleSnapshot2,
+			exampleSnapshot1,
+		},
+	},
+}
+
+func TestPrintSnapshot(t *testing.T) {
+	for _, test := range printSnapshotsCases {
+		t.Run(
+			test.name,
+			func(t *testing.T) {
+				actual := odin.PrintSnapshots(
+					test.snapshots,
+				)
+				test.check(actual, nil, t)
+			},
+		)
+	}
 }
 
 type listSnapshotsCase struct {


### PR DESCRIPTION
This function will return a string containing the output to be printed by the command.

* `PrintSnapshots` implementation is pretty simple: Moved the date/time spec to odin package, making the test use it from there; Then it iterates over the snapshot list, building a list of lines, one per snapshot, which is finally joined to build a single string.
* Then, the command part, just invokes the `PrintSnapshots` giving the list it got from `ListSnapshots` as parameter.
* About the tests of `PrintSnapshots`, since it uses a subset of attributes for `listSnapshotsCase`, it reuses this.
* The RFC8601 is being used again.

Refs [DVX-5662](mydevex.atlassian.net/browse/DVX-5662)