### PR TITLE
Fix and enhance mock for RDS 

### DIFF
--- a/mcc/odin/odin/mock_rds_client_test.go
+++ b/mcc/odin/odin/mock_rds_client_test.go
@@ -16,6 +16,30 @@ type mockRDSClient struct {
 	dbSnapshots          []*rds.DBSnapshot
 }
 
+// AddSnapshots add a list of snapshots to the mock, both in the full
+// list and in the per instance map.
+func (m *mockRDSClient) AddSnapshots(
+	snapshots []*rds.DBSnapshot,
+) {
+	m.dbSnapshots = []*rds.DBSnapshot{}
+	for _, snapshot := range snapshots {
+		m.AddSnapshot(snapshot)
+	}
+}
+
+// AddSnapshot add a new snapshot to the mock, both in the full list
+// and the in the per instance map.
+func (m *mockRDSClient) AddSnapshot(
+	snapshot *rds.DBSnapshot,
+) {
+	m.dbSnapshots = append(m.dbSnapshots, snapshot)
+	id := *snapshot.DBInstanceIdentifier
+	if _, ok := m.dbInstanceSnapshots[id]; !ok {
+		m.dbInstanceSnapshots[id] = []*rds.DBSnapshot{}
+	}
+	m.dbInstanceSnapshots[id] = append(m.dbInstanceSnapshots[id], snapshot)
+}
+
 // DescribeDBSnapshots mocks rds.DescribeDBSnapshots.
 func (m mockRDSClient) DescribeDBSnapshots(
 	describeParams *rds.DescribeDBSnapshotsInput,

--- a/mcc/odin/odin/mock_rds_client_test.go
+++ b/mcc/odin/odin/mock_rds_client_test.go
@@ -186,5 +186,6 @@ func newMockRDSClient() *mockRDSClient {
 	return &mockRDSClient{
 		dbInstancesEndpoints: map[string]rds.Endpoint{},
 		dbInstanceSnapshots:  map[string][]*rds.DBSnapshot{},
+		dbSnapshots:          []*rds.DBSnapshot{},
 	}
 }


### PR DESCRIPTION
This PR fixes the RDS mock initialization, which was not initializing the list of snapshots, and also adds `AddSnapshot` and `AddSnapshots` methods, which help tests to update mock's memory to have expected results to queries to RDS API.

Refs [DVX-5662](mydevex.atlassian.net/browse/DVX-5662)