### PR TITLE
Use RDS mock's `AddSnapshot` and `AddSnapshots` in current tests

### DIFF
--- a/mcc/odin/odin/instance_clone_test.go
+++ b/mcc/odin/odin/instance_clone_test.go
@@ -62,10 +62,7 @@ func TestCloneInstance(t *testing.T) {
 			test.name,
 			func(t *testing.T) {
 				if test.from != "" {
-					snapshot := test.snapshot
-					id := test.snapshot.DBInstanceIdentifier
-					snapshots := []*rds.DBSnapshot{snapshot}
-					svc.dbInstanceSnapshots[*id] = snapshots
+					svc.AddSnapshot(test.snapshot)
 				}
 				createParams := odin.CreateParams{
 					InstanceType: test.instanceType,

--- a/mcc/odin/odin/instance_restore_test.go
+++ b/mcc/odin/odin/instance_restore_test.go
@@ -144,10 +144,7 @@ func TestRestoreInstance(t *testing.T) {
 			test.name,
 			func(t *testing.T) {
 				if test.from != "" {
-					snapshot := test.snapshot
-					id := *snapshot.DBInstanceIdentifier
-					snapshots := []*rds.DBSnapshot{snapshot}
-					svc.dbInstanceSnapshots[id] = snapshots
+					svc.AddSnapshot(test.snapshot)
 				}
 				params := odin.RestoreParams{
 					InstanceType:         test.instanceType,

--- a/mcc/odin/odin/odin_test.go
+++ b/mcc/odin/odin/odin_test.go
@@ -79,10 +79,9 @@ func TestGetLastSnapshot(t *testing.T) {
 		t.Run(
 			test.name,
 			func(t *testing.T) {
-				id := test.identifier
-				svc.dbInstanceSnapshots[id] = test.snapshots
+				svc.AddSnapshots(test.snapshots)
 				actual, err := odin.GetLastSnapshot(
-					id,
+					test.identifier,
 					svc,
 				)
 				test.check(actual, err, t)

--- a/mcc/odin/odin/snapshot_list_test.go
+++ b/mcc/odin/odin/snapshot_list_test.go
@@ -169,7 +169,7 @@ func TestListSnapshots(t *testing.T) {
 		t.Run(
 			test.name,
 			func(t *testing.T) {
-				svc.dbSnapshots = test.snapshots
+				svc.AddSnapshots(test.snapshots)
 				actual, err := odin.ListSnapshots(
 					test.instanceID,
 					svc,


### PR DESCRIPTION
This is pretty simple, it just makes usage of the new methods in the mockRDS (see #70)