### PR TITLE
Make `snapshot list` accept instance name to select only its snapshots

### DIFF
--- a/mcc/odin/odin/snapshot_list.go
+++ b/mcc/odin/odin/snapshot_list.go
@@ -41,6 +41,9 @@ func ListSnapshots(
 	err error,
 ) {
 	input := &rds.DescribeDBSnapshotsInput{}
+	if instanceName != "" {
+		input.SetDBInstanceIdentifier(instanceName)
+	}
 	output, err := svc.DescribeDBSnapshots(input)
 	if err != nil {
 		return

--- a/mcc/odin/odin/snapshot_list_test.go
+++ b/mcc/odin/odin/snapshot_list_test.go
@@ -161,14 +161,29 @@ var listSnapshotsCases = []listSnapshotsCase{
 		},
 		instanceID: "",
 	},
+	// Instance selection
+	{
+		testCase: testCase{
+			expected: []*rds.DBSnapshot{
+				exampleSnapshot2,
+			},
+			expectedError: "",
+		},
+		name: "Two instances two snapshots",
+		snapshots: []*rds.DBSnapshot{
+			exampleSnapshot1,
+			exampleSnapshot2,
+		},
+		instanceID: "develop-rds",
+	},
 }
 
 func TestListSnapshots(t *testing.T) {
-	svc := newMockRDSClient()
 	for _, test := range listSnapshotsCases {
 		t.Run(
 			test.name,
 			func(t *testing.T) {
+				svc := newMockRDSClient()
 				svc.AddSnapshots(test.snapshots)
 				actual, err := odin.ListSnapshots(
 					test.instanceID,


### PR DESCRIPTION
This is the last PR for snapshot listing so far.
If the instance ID/name has been specified, it's used when querying AWS RDS API for snapshots.

Refs [DVX-5662](mydevex.atlassian.net/browse/DVX-5662)