### PR TITLE
DVX-5663: Add mockRDSClient.CreateDBSnapshot

### DIFF
--- a/mcc/odin/odin/mock_rds_client_test.go
+++ b/mcc/odin/odin/mock_rds_client_test.go
@@ -175,6 +175,43 @@ func (m *mockRDSClient) AddSnapshots(
 	)
 }
 
+// CreateDBSnapshot mocks rds.CreateDBSnapshot.
+func (m *mockRDSClient) CreateDBSnapshot(
+	params *rds.CreateDBSnapshotInput,
+) (
+	output *rds.CreateDBSnapshotOutput,
+	err error,
+) {
+	instanceID := params.DBInstanceIdentifier
+	_, instance, err := m.FindInstance(*instanceID)
+	if err != nil {
+		return
+	}
+	if *instance.DBInstanceStatus != "available" {
+		err = fmt.Errorf(
+			"%s instance state is not available",
+			instanceID,
+		)
+	}
+	id := params.DBSnapshotIdentifier
+	_, snapshot, _ := m.FindSnapshot(*id)
+	if snapshot != nil {
+		err = fmt.Errorf(
+			"Snapshot %s already exists",
+			id,
+		)
+		return
+	}
+	createdSnapshot := &rds.DBSnapshot{
+		DBInstanceIdentifier: instanceID,
+		DBSnapshotIdentifier: id,
+	}
+	output = &rds.CreateDBSnapshotOutput{
+		DBSnapshot: createdSnapshot,
+	}
+	return
+}
+
 // DescribeDBSnapshots mocks rds.DescribeDBSnapshots.
 func (m mockRDSClient) DescribeDBSnapshots(
 	describeParams *rds.DescribeDBSnapshotsInput,


### PR DESCRIPTION
This adds the mock for `rds.CreateDBSnapshot` according to its
[specification](http://docs.aws.amazon.com/sdk-for-go/api/service/rds/#RDS.CreateDBSnapshot).

This checks the instance from which the snapshot was requested to be taken
exists, and its state is available, and the snapshot ID requested to use
is not already taken.

I omitted the quota check specified in the spec, since this is a number that might vary,
as all AWS quotas do.
Also, in order to reduce the complexity, I reduced the amount of data being taken into the 
output.

Refs [DVX-5663](mydevex.atlassian.net/browse/DDVX-5663)