### PR TITLE
DVX-5663: Add simple snapshot creation to odin

### DIFF
--- a/mcc/odin/odin/snapshot_create.go
+++ b/mcc/odin/odin/snapshot_create.go
@@ -1,0 +1,29 @@
+package odin
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+)
+
+// CreateSnapshot creates a Snapshot for specified instance.
+func CreateSnapshot(
+	instanceName string,
+	snapshotName string,
+	svc rdsiface.RDSAPI,
+) (
+	result *rds.DBSnapshot,
+	err error,
+) {
+	output, err := svc.CreateDBSnapshot(
+		&rds.CreateDBSnapshotInput{
+			DBInstanceIdentifier: aws.String(instanceName),
+			DBSnapshotIdentifier: aws.String(snapshotName),
+		},
+	)
+	if err != nil {
+		return
+	}
+	result = output.DBSnapshot
+	return
+}

--- a/mcc/odin/odin/snapshot_create_test.go
+++ b/mcc/odin/odin/snapshot_create_test.go
@@ -1,0 +1,58 @@
+package odin_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+
+	"github.com/poka-yoke/spaceflight/mcc/odin/odin"
+)
+
+type createSnapshotsCase struct {
+	testCase
+	name       string
+	instances  []*rds.DBInstance
+	snapshots  []*rds.DBSnapshot
+	snapshotID string
+	instanceID string
+}
+
+var instance1 = &rds.DBInstance{
+	DBInstanceIdentifier: exampleSnapshot3DBID,
+	DBInstanceStatus:     aws.String("available"),
+}
+
+var createSnapshotCases = []createSnapshotsCase{
+	// Create simple snapshot
+	{
+		testCase: testCase{
+			expected:      exampleSnapshot3,
+			expectedError: "",
+		},
+		name:       "Create simple snapshot",
+		instances:  []*rds.DBInstance{instance1},
+		snapshots:  []*rds.DBSnapshot{},
+		snapshotID: *exampleSnapshot3ID,
+		instanceID: *exampleSnapshot3DBID,
+	},
+}
+
+func TestCreateSnapshot(t *testing.T) {
+	for _, test := range createSnapshotCases {
+		t.Run(
+			test.name,
+			func(t *testing.T) {
+				svc := newMockRDSClient()
+				svc.AddInstances(test.instances)
+				svc.AddSnapshots(test.snapshots)
+				actual, err := odin.CreateSnapshot(
+					test.instanceID,
+					test.snapshotID,
+					svc,
+				)
+				test.check(actual, err, t)
+			},
+		)
+	}
+}

--- a/mcc/odin/odin/snapshot_list_test.go
+++ b/mcc/odin/odin/snapshot_list_test.go
@@ -19,6 +19,8 @@ var exampleSnapshot1Time = "2015-06-11T22:00:00+00:00"
 var exampleSnapshot2DBID = aws.String("develop-rds")
 var exampleSnapshot2ID = aws.String("rds:develop-2016-06-11")
 var exampleSnapshot2Time = "2016-06-11T22:00:00+00:00"
+var exampleSnapshot3DBID = aws.String("develop-rds")
+var exampleSnapshot3ID = aws.String("rds:develop-2017-06-11")
 
 func getTime(original string) (parsed time.Time) {
 	parsed, _ = time.Parse(
@@ -46,6 +48,11 @@ var exampleSnapshot2 = &rds.DBSnapshot{
 	MasterUsername:       aws.String("owner"),
 	SnapshotCreateTime:   aws.Time(getTime(exampleSnapshot2Time)),
 	Status:               aws.String("available"),
+}
+
+var exampleSnapshot3 = &rds.DBSnapshot{
+	DBInstanceIdentifier: exampleSnapshot3DBID,
+	DBSnapshotIdentifier: exampleSnapshot3ID,
 }
 
 var exampleSnapshot1Out = fmt.Sprintf(


### PR DESCRIPTION
The `CreateSnapshot` function receives the instance and snapshot
identifiers, and issues the call to create the snapshot with that
name, from the named instance.

Refs [DVX-5663](mydevex.atlassian.net/browse/DVX-5663)