### PR TITLE
Some small fixes in preparation for RDS mock tuning

### DIFF
--- a/mcc/odin/odin/instance_delete_test.go
+++ b/mcc/odin/odin/instance_delete_test.go
@@ -77,7 +77,7 @@ func TestDeleteInstance(t *testing.T) {
 					svc,
 				)
 				test.check("", err, t)
-				_, instance, _ := svc.FindInstance(
+				_, instance, _ := svc.findInstance(
 					test.identifier,
 				)
 				if instance != nil {

--- a/mcc/odin/odin/mock_rds_client_test.go
+++ b/mcc/odin/odin/mock_rds_client_test.go
@@ -64,7 +64,7 @@ func (m *mockRDSClient) DeleteDBInstance(
 	if err = params.Validate(); err != nil {
 		return
 	}
-	_, instance, err := m.FindInstance(*params.DBInstanceIdentifier)
+	_, instance, err := m.findInstance(*params.DBInstanceIdentifier)
 	if err != nil {
 		return
 	}
@@ -128,9 +128,9 @@ func (m mockRDSClient) FindSnapshot(id string) (
 	return
 }
 
-// FindInstance return index and instance in mockRDSClient.dbInstances
+// findInstance return index and instance in mockRDSClient.dbInstances
 // for a specific id.
-func (m mockRDSClient) FindInstance(id string) (
+func (m mockRDSClient) findInstance(id string) (
 	index int,
 	instance *rds.DBInstance,
 	err error,
@@ -183,7 +183,7 @@ func (m *mockRDSClient) CreateDBSnapshot(
 	err error,
 ) {
 	instanceID := params.DBInstanceIdentifier
-	_, instance, err := m.FindInstance(*instanceID)
+	_, instance, err := m.findInstance(*instanceID)
 	if err != nil {
 		return
 	}
@@ -248,7 +248,7 @@ func (m *mockRDSClient) DescribeDBInstances(
 	err error,
 ) {
 	id := describeParams.DBInstanceIdentifier
-	index, instance, err := m.FindInstance(*id)
+	index, instance, err := m.findInstance(*id)
 	if err != nil {
 		return
 	}

--- a/mcc/odin/odin/mock_rds_client_test.go
+++ b/mcc/odin/odin/mock_rds_client_test.go
@@ -378,17 +378,17 @@ func (m *mockRDSClient) RestoreDBInstanceFromDBSnapshot(
 
 // ModifyDBInstance mocks rds.ModifyDBInstance.
 func (m mockRDSClient) ModifyDBInstance(
-	inputParams *rds.ModifyDBInstanceInput,
+	params *rds.ModifyDBInstanceInput,
 ) (
-	result *rds.ModifyDBInstanceOutput,
+	out *rds.ModifyDBInstanceOutput,
 	err error,
 ) {
-	if err = inputParams.Validate(); err != nil {
+	if err = params.Validate(); err != nil {
 		return
 	}
-	result = &rds.ModifyDBInstanceOutput{
+	out = &rds.ModifyDBInstanceOutput{
 		DBInstance: &rds.DBInstance{
-			DBInstanceIdentifier: inputParams.DBInstanceIdentifier,
+			DBInstanceIdentifier: params.DBInstanceIdentifier,
 		},
 	}
 	return


### PR DESCRIPTION
This PR changes includes:
* Unexport of `mockRDSClient.FindInstances`, being a helper method.
* Small variable changes in `mockRDSClient.ModifyDBInstance` method.

Refs [DVX-5664](https://mydevex.atlassian.net/browse/DVX-5664)