### PR TITLE
Improve behaviour of mockRDSClient.ModifyDBInstance

### DIFF
--- a/mcc/odin/odin/instance_delete_test.go
+++ b/mcc/odin/odin/instance_delete_test.go
@@ -70,7 +70,7 @@ func TestDeleteInstance(t *testing.T) {
 		t.Run(
 			test.name,
 			func(t *testing.T) {
-				svc.AddInstances(test.instances)
+				svc.addInstances(test.instances)
 				err := odin.DeleteInstance(
 					test.identifier,
 					test.snapshotID,

--- a/mcc/odin/odin/mock_rds_client_test.go
+++ b/mcc/odin/odin/mock_rds_client_test.go
@@ -153,8 +153,8 @@ func (m mockRDSClient) findInstance(id string) (
 	return
 }
 
-// AddInstances add a list of instances to the mock
-func (m *mockRDSClient) AddInstances(
+// addInstances add a list of instances to the mock
+func (m *mockRDSClient) addInstances(
 	instances []*rds.DBInstance,
 ) {
 	m.dbInstances = []*rds.DBInstance{}

--- a/mcc/odin/odin/snapshot_create_test.go
+++ b/mcc/odin/odin/snapshot_create_test.go
@@ -95,7 +95,7 @@ func TestCreateSnapshot(t *testing.T) {
 			test.name,
 			func(t *testing.T) {
 				svc := newMockRDSClient()
-				svc.AddInstances(test.instances)
+				svc.addInstances(test.instances)
 				svc.AddSnapshots(test.snapshots)
 				actual, err := odin.CreateSnapshot(
 					test.instanceID,


### PR DESCRIPTION
This PR makes `ModifyDBInstance` mock to fail when:
* The instance doesn't exist
* The instance is not in available state

This mock is also extended to make:
* `ModifyDBInstance` is now updating the instance DBInstanceClass, so when `scale` is being used, the mock will update this.
* `ModifyDBInstance` also changes the instance state to `modifying`.
* `DescribeDBInstances` will also update the instance state to `available` whenever the previous state is `creating` or `modifying`.

All these changes will be used by tests in incoming PRs.

This PR also unexports `addInstances` helper.

Refs [DVX-5664](https://mydevex.atlassian.net/browse/DVX-5664)