### PR TITLE
Fix bugs in odin instance scale

### DIFF
--- a/mcc/odin/cmd/instance_scale.go
+++ b/mcc/odin/cmd/instance_scale.go
@@ -9,7 +9,10 @@ import (
 	"github.com/poka-yoke/spaceflight/mcc/odin/odin"
 )
 
-// instanceScaleCmd represents the instance scale command
+var delay bool
+
+// instanceScaleCmd invokes the ScaleInstance function with defined
+// parameter's from user's input.
 var instanceScaleCmd = &cobra.Command{
 	Use:   "scale [flags] identifier",
 	Short: "Scales a database",
@@ -22,6 +25,7 @@ var instanceScaleCmd = &cobra.Command{
 		result, err := odin.ScaleInstance(
 			args[0],
 			instanceType,
+			delay,
 			svc,
 		)
 		if err != nil {
@@ -45,6 +49,13 @@ func init() {
 		"t",
 		"db.m1.small",
 		"Instance type to use when creating DB Instance",
+	)
+	instanceScaleCmd.PersistentFlags().BoolVarP(
+		&delay,
+		"delay",
+		"d",
+		false,
+		"Scales on next reboot or during maintenance",
 	)
 
 	// Cobra supports local flags which will only run when this command

--- a/mcc/odin/odin/instance_scale.go
+++ b/mcc/odin/odin/instance_scale.go
@@ -12,14 +12,17 @@ import (
 func ScaleInstance(
 	instanceName string,
 	instanceType string,
+	delayChange bool,
 	svc rdsiface.RDSAPI,
 ) (result string, err error) {
-	out, err := svc.ModifyDBInstance(
-		&rds.ModifyDBInstanceInput{
-			DBInstanceIdentifier: aws.String(instanceName),
-			DBInstanceClass:      aws.String(instanceType),
-		},
-	)
+	in := &rds.ModifyDBInstanceInput{
+		DBInstanceIdentifier: aws.String(instanceName),
+		DBInstanceClass:      aws.String(instanceType),
+	}
+	if !delayChange {
+		in.ApplyImmediately = aws.Bool(true)
+	}
+	out, err := svc.ModifyDBInstance(in)
 	if err != nil {
 		return
 	}

--- a/mcc/odin/odin/instance_scale.go
+++ b/mcc/odin/odin/instance_scale.go
@@ -26,6 +26,10 @@ func ScaleInstance(
 	if err != nil {
 		return
 	}
+	err = WaitForInstance(out.DBInstance, svc, "modifying")
+	if err != nil {
+		return
+	}
 	err = WaitForInstance(out.DBInstance, svc, "available")
 	if err != nil {
 		return

--- a/mcc/odin/odin/instance_scale_test.go
+++ b/mcc/odin/odin/instance_scale_test.go
@@ -15,6 +15,7 @@ type scaleInstanceCase struct {
 	name         string
 	identifier   string
 	instanceType string
+	delayChange  bool
 	instances    []*rds.DBInstance
 }
 
@@ -28,6 +29,7 @@ var scaleInstanceCases = []scaleInstanceCase{
 		name:         "Scaling up instance",
 		identifier:   "test1",
 		instanceType: "db.m1.small",
+		delayChange:  false,
 		instances: []*rds.DBInstance{
 			{
 				DBInstanceIdentifier: aws.String("test1"),
@@ -45,6 +47,7 @@ var scaleInstanceCases = []scaleInstanceCase{
 		name:         "Fail to scale up non existing instance",
 		identifier:   "test1",
 		instanceType: "db.m1.small",
+		delayChange:  false,
 		instances:    []*rds.DBInstance{},
 	},
 	// Fail to scale up non available instance
@@ -56,6 +59,7 @@ var scaleInstanceCases = []scaleInstanceCase{
 		name:         "Fail to scale up non available instance",
 		identifier:   "test1",
 		instanceType: "db.m1.small",
+		delayChange:  false,
 		instances: []*rds.DBInstance{
 			{
 				DBInstanceIdentifier: aws.String("test1"),
@@ -73,6 +77,25 @@ var scaleInstanceCases = []scaleInstanceCase{
 		name:         "Scaling down instance",
 		identifier:   "test1",
 		instanceType: "db.m1.small",
+		delayChange:  false,
+		instances: []*rds.DBInstance{
+			{
+				DBInstanceIdentifier: aws.String("test1"),
+				DBInstanceClass:      aws.String("db.m1.medium"),
+				DBInstanceStatus:     aws.String("available"),
+			},
+		},
+	},
+	// Delayed scaling down instance
+	{
+		testCase: testCase{
+			expected:      "Instance test1 is db.m1.medium",
+			expectedError: "",
+		},
+		name:         "Scaling down instance",
+		identifier:   "test1",
+		instanceType: "db.m1.small",
+		delayChange:  true,
 		instances: []*rds.DBInstance{
 			{
 				DBInstanceIdentifier: aws.String("test1"),
@@ -94,6 +117,7 @@ func TestScaleInstance(t *testing.T) {
 				actual, err := odin.ScaleInstance(
 					test.identifier,
 					test.instanceType,
+					test.delayChange,
 					svc,
 				)
 				test.check(actual, err, t)

--- a/mcc/odin/odin/mock_rds_client_test.go
+++ b/mcc/odin/odin/mock_rds_client_test.go
@@ -400,11 +400,14 @@ func (m *mockRDSClient) ModifyDBInstance(
 			*params.DBInstanceIdentifier,
 		)
 	}
-	if params.DBInstanceClass != nil &&
-		params.DBInstanceClass != instance.DBInstanceClass {
-		instance.DBInstanceClass = params.DBInstanceClass
+	if params.ApplyImmediately != nil &&
+		*params.ApplyImmediately {
+		instance.DBInstanceStatus = aws.String("modifying")
+		if params.DBInstanceClass != nil &&
+			params.DBInstanceClass != instance.DBInstanceClass {
+			instance.DBInstanceClass = params.DBInstanceClass
+		}
 	}
-	instance.DBInstanceStatus = aws.String("modifying")
 	m.dbInstances[index] = instance
 	out = &rds.ModifyDBInstanceOutput{
 		DBInstance: instance,


### PR DESCRIPTION
This PR fixes two bugs:
* The changes sent to AWS can be applied immediately or delayed.
  This should be controlled by a switch, wired into the CLI.
* The command needs to wait for the instance to be modifying then
  available.

Refs [DVX-5664](https://mydevex.atlassian.net/browse/DVX-5664)