### PR TITLE
Cronitor backend for health command

### DIFF
--- a/mcc/health/cmd/create.go
+++ b/mcc/health/cmd/create.go
@@ -10,7 +10,14 @@ import (
 	"github.com/poka-yoke/spaceflight/mcc/health/health"
 )
 
+// Check is an interface to be implemented by all backend providers
+type Check interface {
+	SetAPIKey(string)
+	Create(string, map[string]interface{}) (*http.Response, error)
+}
+
 var apikey, endpoint, schedule, name, tags, sep string
+var check Check
 
 // createCmd represents the create command
 var createCmd = &cobra.Command{
@@ -21,7 +28,7 @@ var createCmd = &cobra.Command{
 		message := make(map[string]interface{})
 		out := []string{}
 		check := health.NewCheck()
-		check.APIKey = apikey
+		check.SetAPIKey(apikey)
 		if schedule != "" {
 			message["schedule"] = schedule
 			out = append(out, schedule)

--- a/mcc/health/cronitor/cronitor.go
+++ b/mcc/health/cronitor/cronitor.go
@@ -1,0 +1,64 @@
+package cronitor
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// Check represents the checking service and holds service dependent
+// data
+type Check struct {
+	APIKey string
+}
+
+// SetAPIKey configures the backend with proper API Key
+func (c *Check) SetAPIKey(key string) {
+	c.APIKey = key
+}
+
+// Create adds a new check throuh an API call
+func (c *Check) Create(endpoint string, message map[string]interface{}) (res *http.Response, err error) {
+	// Request body
+	buf, err := json.Marshal(message)
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequest(
+		http.MethodPost,
+		endpoint,
+		bytes.NewBuffer(buf),
+	)
+	if err != nil {
+		return
+	}
+	// Set headers
+	req.Header.Add("Content-Type", "application/json")
+	req.SetBasicAuth(c.APIKey, "")
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// ParseResponse converts the services' response body into a map
+func ParseResponse(in io.ReadCloser) (map[string]interface{}, error) {
+	m := make(map[string]interface{})
+	body, err := ioutil.ReadAll(in)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(body, &m)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// NewCheck creates an empty Check
+func NewCheck() *Check {
+	return &Check{}
+}

--- a/mcc/health/cronitor/cronitor_test.go
+++ b/mcc/health/cronitor/cronitor_test.go
@@ -1,0 +1,201 @@
+package cronitor
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type healthCase struct {
+	name, schedule, channels, tags string
+	slug, email, note              string
+	status                         int
+}
+
+var healthCases = []healthCase{
+	{
+		name:     "New check",
+		schedule: "* * * * *",
+		channels: "*",
+		email:    "test@example.com",
+		tags:     "new minute alert",
+		slug:     "f618072a-7bde-4eee-af63-71a77c5723bc",
+		note:     "new minute alert",
+		status:   http.StatusCreated,
+	},
+	{
+		name:     "New check",
+		schedule: "0 * * * *",
+		channels: "*",
+		email:    "test@example.com",
+		tags:     "new hourly alert",
+		slug:     "f618072a-7bde-4eee-af63-71a77c5723bc",
+		note:     "new hourly alert",
+		status:   http.StatusCreated,
+	},
+	{
+		name:     "New check",
+		schedule: "0 * * * *",
+		email:    "test@example.com",
+		tags:     "new hourly noalert",
+		slug:     "f618072a-7bde-4eee-af63-71a77c5723bc",
+		note:     "new hourly noalert",
+		status:   http.StatusCreated,
+	},
+}
+
+func healthCheckServer(t *testing.T) func(http.ResponseWriter, *http.Request) {
+	return func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		// Process headers
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf(
+				"Expected header to have Content-Type %s, received %s",
+				"application/json",
+				r.Header.Get("Content-Type"),
+			)
+		}
+		if r.Header.Get("Authorization") == "" {
+			t.Errorf("Expected header to have Authorization")
+		}
+		// Process body
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := make(map[string]interface{})
+		err = json.Unmarshal(body, &s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, d := range healthCases {
+			if d.note == s["note"] {
+				w.Header().Set(
+					"Content-Type",
+					"application/json",
+				)
+				w.WriteHeader(d.status)
+				b := map[string]interface{}{
+					"code":        d.slug,
+					"key":         nil,
+					"type":        "heartbeat",
+					"dev":         false,
+					"initialized": false,
+					"disabled":    false,
+					"paused":      false,
+					"passing":     true,
+					"running":     false,
+					"status":      "Waiting for the first ping",
+					"name":        d.name,
+					"notifications": map[string][]string{
+						"templates": []string{},
+						"pagerduty": []string{},
+						"slack":     []string{},
+						"phones":    []string{},
+						"emails":    []string{d.email},
+						"webhooks":  []string{},
+						"hipchat":   []string{},
+					},
+					"tags":     strings.Split(d.tags, " "),
+					"timezone": nil,
+					"rules": []map[string]interface{}{
+						{
+							"rule_type":               "not_on_schedule",
+							"hours_to_followup_alert": 8,
+							"value":                   d.schedule,
+						},
+					},
+					"request":                  nil,
+					"request_interval_seconds": nil,
+					"note":                 d.note,
+					"has_duration_history": false,
+					"created":              time.Now().Format("2006-01-02T15:04:05-07:00"),
+				}
+				buf, err := json.Marshal(b)
+				if err != nil {
+					t.Error(err)
+				}
+				fmt.Fprintln(w, bytes.NewBuffer(buf))
+				return
+			}
+		}
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+	}
+}
+
+func TestCheckCreate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(healthCheckServer(t)))
+	defer server.Close()
+
+	for _, tc := range healthCases {
+		check := NewCheck()
+		check.APIKey = "your-api-key"
+		message := map[string]interface{}{
+			"tags": strings.Split(tc.tags, " "),
+			"name": tc.name,
+			"type": "heartbeat",
+			"notifications": map[string][]string{
+				"emails": []string{
+					tc.email,
+				},
+			},
+			"rules": []map[string]interface{}{
+				{
+					"rule_type": "not_on_schedule",
+					"value":     tc.schedule,
+				},
+			},
+			"note": tc.note,
+		}
+		res, err := check.Create(server.URL, message)
+		if err != nil {
+			t.Error(err)
+		}
+		if res.StatusCode != tc.status {
+			t.Errorf(
+				"Expected status %d but received %d: %s",
+				tc.status,
+				res.StatusCode,
+				res.Status,
+			)
+		}
+		m, err := ParseResponse(res.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		if m["name"] != tc.name {
+			t.Errorf(
+				"Wrong name. Expected %s, found %s",
+				tc.name,
+				m["name"],
+			)
+		}
+		tmp, ok := m["tags"].([]interface{})
+		if !ok {
+			t.Error("Tags field is not slice of interfaces")
+		}
+		var tags []string
+		for _, v := range tmp {
+			s, ok := v.(string)
+			if !ok {
+				t.Error("Tag contents are not strings")
+			}
+			tags = append(tags, s)
+		}
+		if strings.Join(tags, " ") != tc.tags {
+			t.Errorf(
+				"Wrong tags. Expected %s, found %v",
+				tc.tags,
+				strings.Join(tags, " "),
+			)
+		}
+	}
+}

--- a/mcc/health/health/health.go
+++ b/mcc/health/health/health.go
@@ -15,6 +15,11 @@ type Check struct {
 	APIKey string
 }
 
+// SetAPIKey configures the backend with proper API Key
+func (c *Check) SetAPIKey(key string) {
+	c.APIKey = key
+}
+
 // Create adds a new check throuh an API call
 func (c *Check) Create(endpoint string, message map[string]interface{}) (res *http.Response, err error) {
 	// Request body


### PR DESCRIPTION
Should be easier to review by commit.

This is a first approach to supporting both cronitor.io and healthchecks.io in health command. It requires a deep refactor to unify code paths and reduce code duplication in both tests and implementation. The refactor has been held back to ease review of the code. This PR provides bare minimal functionality for cronitor.

**DVX-5909: Create Check interface**
Modify health implementation to respect the new interface. This will
allow further abstraction of the changes to allow for multiple
providers.

**DVX-5909: Add cronitor package**
This implements the backend for cronitor.io from a copy of the
healthchecks.io backend. There's lots of code duplication that should
be refactored to be the same for both backends.

**DVX-5909: Make command select backend**
Based on the address in the endpoint it selects one backend or the
other. This is a very naïve first approach to the issue with lots of
code repetition.