### PR TITLE
Finish cronitor basic integration and start cleaning up the common code

### DIFF
--- a/mcc/health/cmd/create.go
+++ b/mcc/health/cmd/create.go
@@ -18,7 +18,7 @@ type Check interface {
 	Create(string, map[string]interface{}) (*http.Response, error)
 }
 
-var apikey, endpoint, schedule, name, tags, sep string
+var apikey, endpoint, schedule, name, tags, sep, email string
 var check Check
 
 // createCmd represents the create command
@@ -79,6 +79,13 @@ var createCmd = &cobra.Command{
 			if tags != "" {
 				message["tags"] = strings.Split(tags, " ")
 				out = append(out, tags)
+			}
+			if email != "" {
+				message["notifications"] = map[string][]string{
+					"emails": []string{
+						email,
+					},
+				}
 			}
 			res, err := check.Create(endpoint, message)
 			if err != nil {
@@ -149,6 +156,13 @@ func init() {
 		"",
 		" ",
 		"Field separator string for output",
+	)
+	createCmd.PersistentFlags().StringVarP(
+		&email,
+		"email",
+		"",
+		"",
+		"Contact email adresses (cronitor only)",
 	)
 
 	// Cobra supports local flags which will only run when this command

--- a/mcc/health/cmd/create.go
+++ b/mcc/health/cmd/create.go
@@ -15,7 +15,7 @@ import (
 // Check is an interface to be implemented by all backend providers
 type Check interface {
 	SetAPIKey(string)
-	Create(string, map[string]interface{}) (*http.Response, error)
+	Create(string, map[string]interface{}) (*http.Request, error)
 }
 
 var apikey, endpoint, schedule, name, tags, sep, email string
@@ -45,7 +45,11 @@ var createCmd = &cobra.Command{
 				message["tags"] = tags
 				out = append(out, tags)
 			}
-			res, err := check.Create(endpoint, message)
+			req, err := check.Create(endpoint, message)
+			if err != nil {
+				log.Fatal(err)
+			}
+			res, err := http.DefaultClient.Do(req)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -87,11 +91,15 @@ var createCmd = &cobra.Command{
 					},
 				}
 			}
-			res, err := check.Create(endpoint, message)
+			req, err := check.Create(endpoint, message)
 			if err != nil {
 				log.Fatal(err)
 			}
-			m, err := health.ParseResponse(res.Body)
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				log.Fatal(err)
+			}
+			m, err := cronitor.ParseResponse(res.Body)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/mcc/health/cronitor/cronitor.go
+++ b/mcc/health/cronitor/cronitor.go
@@ -20,13 +20,13 @@ func (c *Check) SetAPIKey(key string) {
 }
 
 // Create adds a new check throuh an API call
-func (c *Check) Create(endpoint string, message map[string]interface{}) (res *http.Response, err error) {
+func (c *Check) Create(endpoint string, message map[string]interface{}) (req *http.Request, err error) {
 	// Request body
 	buf, err := json.Marshal(message)
 	if err != nil {
 		return
 	}
-	req, err := http.NewRequest(
+	req, err = http.NewRequest(
 		http.MethodPost,
 		endpoint,
 		bytes.NewBuffer(buf),
@@ -37,10 +37,6 @@ func (c *Check) Create(endpoint string, message map[string]interface{}) (res *ht
 	// Set headers
 	req.Header.Add("Content-Type", "application/json")
 	req.SetBasicAuth(c.APIKey, "")
-	res, err = http.DefaultClient.Do(req)
-	if err != nil {
-		return
-	}
 	return
 }
 

--- a/mcc/health/cronitor/cronitor_test.go
+++ b/mcc/health/cronitor/cronitor_test.go
@@ -155,7 +155,11 @@ func TestCheckCreate(t *testing.T) {
 			},
 			"note": tc.note,
 		}
-		res, err := check.Create(server.URL, message)
+		req, err := check.Create(server.URL, message)
+		if err != nil {
+			t.Error(err)
+		}
+		res, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Error(err)
 		}

--- a/mcc/health/health/health.go
+++ b/mcc/health/health/health.go
@@ -21,13 +21,13 @@ func (c *Check) SetAPIKey(key string) {
 }
 
 // Create adds a new check throuh an API call
-func (c *Check) Create(endpoint string, message map[string]interface{}) (res *http.Response, err error) {
+func (c *Check) Create(endpoint string, message map[string]interface{}) (req *http.Request, err error) {
 	// Request body
 	buf, err := json.Marshal(message)
 	if err != nil {
 		return
 	}
-	req, err := http.NewRequest(
+	req, err = http.NewRequest(
 		http.MethodPost,
 		endpoint,
 		bytes.NewBuffer(buf),
@@ -38,10 +38,6 @@ func (c *Check) Create(endpoint string, message map[string]interface{}) (res *ht
 	// Set headers
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("X-Api-Key", c.APIKey)
-	res, err = http.DefaultClient.Do(req)
-	if err != nil {
-		return
-	}
 	return
 }
 

--- a/mcc/health/health/health_test.go
+++ b/mcc/health/health/health_test.go
@@ -121,7 +121,11 @@ func TestCheckCreate(t *testing.T) {
 			"schedule": tt.schedule,
 			"name":     tt.name,
 		}
-		res, err := check.Create(server.URL, message)
+		req, err := check.Create(server.URL, message)
+		if err != nil {
+			t.Error(err)
+		}
+		res, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
**DVX-5909: Add email notification for cronitor.io**
When creating the check also add the notification email address. This
should make the cronitor feature complete for migrating our current
crons there.

**DVX-5909: Modify Check.Create signature**
This allows to just return a http.Request object per service and
handle the http connection from the main command, so we can reuse as
much code as possible there.