### PR TITLE
Health cleanup continuing

### DIFF
--- a/mcc/health/cmd/create.go
+++ b/mcc/health/cmd/create.go
@@ -33,18 +33,7 @@ var createCmd = &cobra.Command{
 		case strings.Contains(endpoint, "healthchecks.io"):
 			check = health.NewCheck()
 			check.SetAPIKey(apikey)
-			if schedule != "" {
-				message["schedule"] = schedule
-				out = append(out, schedule)
-			}
-			if name != "" {
-				message["name"] = name
-				out = append(out, name)
-			}
-			if tags != "" {
-				message["tags"] = tags
-				out = append(out, tags)
-			}
+			message = health.SetMessage(schedule, name, tags)
 			req, err := check.Create(endpoint, message)
 			if err != nil {
 				log.Fatal(err)
@@ -62,35 +51,11 @@ var createCmd = &cobra.Command{
 				log.Fatal("Can't access field update_url")
 			}
 			slug := health.GetSlugFromURL(v)
-			out = append(out, slug)
+			out = []string{schedule, name, tags, slug}
 		case strings.Contains(endpoint, "cronitor.io"):
 			check = cronitor.NewCheck()
 			check.SetAPIKey(apikey)
-			message["type"] = "heartbeat"
-			if schedule != "" {
-				out = append(out, schedule)
-				message["rules"] = []map[string]interface{}{
-					{
-						"value":     schedule,
-						"rule_type": "not_on_schedule",
-					},
-				}
-			}
-			if name != "" {
-				message["name"] = name
-				out = append(out, name)
-			}
-			if tags != "" {
-				message["tags"] = strings.Split(tags, " ")
-				out = append(out, tags)
-			}
-			if email != "" {
-				message["notifications"] = map[string][]string{
-					"emails": []string{
-						email,
-					},
-				}
-			}
+			message = cronitor.SetMessage(schedule, name, tags, email)
 			req, err := check.Create(endpoint, message)
 			if err != nil {
 				log.Fatal(err)
@@ -107,7 +72,7 @@ var createCmd = &cobra.Command{
 			if !ok {
 				log.Fatal("Can't retrieve id")
 			}
-			out = append(out, v)
+			out = []string{schedule, name, tags, v}
 		default:
 			log.Fatal("Unrecognized provider")
 		}

--- a/mcc/health/cronitor/cronitor.go
+++ b/mcc/health/cronitor/cronitor.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 // Check represents the checking service and holds service dependent
@@ -38,6 +39,34 @@ func (c *Check) Create(endpoint string, message map[string]interface{}) (req *ht
 	req.Header.Add("Content-Type", "application/json")
 	req.SetBasicAuth(c.APIKey, "")
 	return
+}
+
+// SetMessage builds the request body for cronitor.io
+func SetMessage(schedule, name, tags, email string) map[string]interface{} {
+	message := make(map[string]interface{})
+	message["type"] = "heartbeat"
+	if schedule != "" {
+		message["rules"] = []map[string]interface{}{
+			{
+				"value":     schedule,
+				"rule_type": "not_on_schedule",
+			},
+		}
+	}
+	if name != "" {
+		message["name"] = name
+	}
+	if tags != "" {
+		message["tags"] = strings.Split(tags, " ")
+	}
+	if email != "" {
+		message["notifications"] = map[string][]string{
+			"emails": []string{
+				email,
+			},
+		}
+	}
+	return message
 }
 
 // ParseResponse converts the services' response body into a map

--- a/mcc/health/health/health.go
+++ b/mcc/health/health/health.go
@@ -41,6 +41,21 @@ func (c *Check) Create(endpoint string, message map[string]interface{}) (req *ht
 	return
 }
 
+// SetMessage builds the request body for healthchecks.io
+func SetMessage(schedule, name, tags string) map[string]interface{} {
+	message := make(map[string]interface{})
+	if schedule != "" {
+		message["schedule"] = schedule
+	}
+	if name != "" {
+		message["name"] = name
+	}
+	if tags != "" {
+		message["tags"] = tags
+	}
+	return message
+}
+
 // GetSlugFromURL extracts the slug from any of the returned URLs
 func GetSlugFromURL(m string) (s string) {
 	s = strings.TrimPrefix(

--- a/mcc/health/health/health_test.go
+++ b/mcc/health/health/health_test.go
@@ -214,3 +214,50 @@ func TestGetSlugFromURL(t *testing.T) {
 		}
 	}
 }
+
+func TestSetMessage(t *testing.T) {
+	data := []struct {
+		schedule, name, tags string
+	}{
+		{
+			schedule: "* * * * *",
+			name:     "test",
+			tags:     "cron",
+		},
+	}
+	for _, tc := range data {
+		out := SetMessage(tc.schedule, tc.name, tc.tags)
+		err := verifyKeyExists("schedule", tc.schedule, out)
+		if err != nil {
+			t.Error(err)
+		}
+		err = verifyKeyExists("name", tc.name, out)
+		if err != nil {
+			t.Error(err)
+		}
+		err = verifyKeyExists("tags", tc.tags, out)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func verifyKeyExists(field, expected string, container map[string]interface{}) error {
+	v, ok := container[field]
+	if !ok {
+		return fmt.Errorf("Expected %s field was present", field)
+	}
+	typefield, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("Expected %s field to be string", field)
+	}
+	if typefield != expected {
+		return fmt.Errorf(
+			"Expected %s field to contain %s, got %s",
+			field,
+			expected,
+			typefield,
+		)
+	}
+	return nil
+}


### PR DESCRIPTION
**DVX-5909: Build message per-backend**
Add a function to create a message according to the format required by
each backend, so we can reuse most of the main command function.

**DVX-5909: Unify common actions in main function**
Rearrange actions so we can reuse common areas of the function:
sending request and reading response.