### PR TITLE
Avoid nil pointer dereference

### DIFF
--- a/mcc/got/got/got.go
+++ b/mcc/got/got/got.go
@@ -156,6 +156,7 @@ func WaitForChangeToComplete(
 		if err != nil {
 			log.Printf("Error! Retry in %s", sleep)
 			time.Sleep(sleep)
+			continue
 		}
 		if *getChangeOutput.ChangeInfo.Status == route53.ChangeStatusInsync {
 			break


### PR DESCRIPTION
If we got inside the `err != nil` branch, `getChangeOutput` could be
nil and accessing its members would cause a runtime panic.

The `continue` returns us to the beginning of the loop if that
happens, effectively retrying the request, so `getChangeOutput`
shouldn't be `nil` when accessed.