### PR TITLE
Fix scheme validation in sidekiq monitor (dextre)

### DIFF
--- a/mss/dextre/cmd/sidekiq.go
+++ b/mss/dextre/cmd/sidekiq.go
@@ -17,8 +17,7 @@ var sidekiqCmd = &cobra.Command{
 	Long: `This command connects to an exposed API of sidekiq, scrapes the
 endpoints and offers the information gathered in the form of a Nagios check.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if !strings.HasPrefix(baseURL, "http://") ||
-			!strings.HasPrefix(baseURL, "https://") {
+		if sidekiq.ValidScheme(baseURL) {
 			log.Fatal("Unknown scheme: ", baseURL)
 		}
 		info := sidekiq.ProcessGetResponse(baseURL)

--- a/mss/dextre/sidekiq/sidekiq.go
+++ b/mss/dextre/sidekiq/sidekiq.go
@@ -15,6 +15,8 @@ func must(err error) {
 	}
 }
 
+// ValidScheme returns true if url is on a valid scheme. It
+// returns false otherwise.
 func ValidScheme(url string) bool {
 	if !strings.HasPrefix(url, "http://") &&
 		!strings.HasPrefix(url, "https://") {

--- a/mss/dextre/sidekiq/sidekiq.go
+++ b/mss/dextre/sidekiq/sidekiq.go
@@ -15,6 +15,14 @@ func must(err error) {
 	}
 }
 
+func ValidScheme(url string) bool {
+	if !strings.HasPrefix(url, "http://") &&
+		!strings.HasPrefix(url, "https://") {
+		return false
+	}
+	return true
+}
+
 type sidekiqStats struct {
 	Processed      int64   `json:"processed"`
 	Failed         int64   `json:"failed"`

--- a/mss/dextre/sidekiq/sidekiq_test.go
+++ b/mss/dextre/sidekiq/sidekiq_test.go
@@ -220,3 +220,37 @@ func compareSidekiqAttribs(a, b sidekiqAttribs) bool {
 	}
 	return res
 }
+
+var schemesTable = []struct {
+	url      string
+	expected bool
+}{
+	{
+		url:      "https://this.is.valid",
+		expected: true,
+	},
+	{
+		url:      "http://this.is.valid.too",
+		expected: true,
+	},
+	{
+		url:      "hkp://this.is.NOT.valid",
+		expected: false,
+	},
+}
+
+func TestValidScheme(t *testing.T) {
+	for _, tc := range schemesTable {
+		result := ValidScheme(tc.url)
+		if result != tc.expected {
+			msg := "Should not be valid"
+			if tc.expected {
+				msg = "Should be valid"
+			}
+			t.Error(
+				tc.url,
+				msg,
+			)
+		}
+	}
+}


### PR DESCRIPTION
This adds a function to validate the scheme for the sidekiq check API,
instead of having the validation hardcoded in the command implementation.

This way, it is testable.

Also adds test, and fixes the behavior.

The command now uses the scheme validation function, instead of having this
hardocded.