### PR TITLE
Hackathon dotgo tests

### DIFF
--- a/mcc/capcom/capcom/capcom.go
+++ b/mcc/capcom/capcom/capcom.go
@@ -167,10 +167,11 @@ func BuildIPPermission(
 	perm *ec2.IpPermission,
 	err error,
 ) {
-	perm = &ec2.IpPermission{}
-	perm.FromPort = &port
-	perm.ToPort = &port
-	perm.IpProtocol = &proto
+	perm = &ec2.IpPermission{
+		FromPort:   &port,
+		ToPort:     &port,
+		IpProtocol: &proto,
+	}
 	if strings.HasPrefix(origin, "sg-") {
 		// It's a security group
 		perm.UserIdGroupPairs = []*ec2.UserIdGroupPair{{GroupId: &origin}}

--- a/mcc/capcom/capcom/capcom.go
+++ b/mcc/capcom/capcom/capcom.go
@@ -47,11 +47,11 @@ func AuthorizeAccessToSecurityGroup(
 	perm *ec2.IpPermission,
 	destination string,
 ) *ec2.AuthorizeSecurityGroupIngressOutput {
-	params := &ec2.AuthorizeSecurityGroupIngressInput{
-		GroupId:       &destination,
-		IpPermissions: []*ec2.IpPermission{perm},
-	}
-	out, error := svc.AuthorizeSecurityGroupIngress(params)
+	out, error := svc.AuthorizeSecurityGroupIngress(
+		&ec2.AuthorizeSecurityGroupIngressInput{
+			GroupId:       &destination,
+			IpPermissions: []*ec2.IpPermission{perm},
+		})
 	if error != nil {
 		log.Panic(error)
 	}
@@ -65,11 +65,11 @@ func RevokeAccessToSecurityGroup(
 	perm *ec2.IpPermission,
 	destination string,
 ) *ec2.RevokeSecurityGroupIngressOutput {
-	params := &ec2.RevokeSecurityGroupIngressInput{
-		GroupId:       &destination,
-		IpPermissions: []*ec2.IpPermission{perm},
-	}
-	out, error := svc.RevokeSecurityGroupIngress(params)
+	out, error := svc.RevokeSecurityGroupIngress(
+		&ec2.RevokeSecurityGroupIngressInput{
+			GroupId:       &destination,
+			IpPermissions: []*ec2.IpPermission{perm},
+		})
 	if error != nil {
 		log.Panic(error)
 	}
@@ -193,15 +193,15 @@ func BuildIPPermission(
 
 // FindSGByName gets an array of sgids for a name search
 func FindSGByName(name string, vpc string, svc ec2iface.EC2API) (ret []string) {
-	params := &ec2.DescribeSecurityGroupsInput{
-		Filters: []*ec2.Filter{
-			&ec2.Filter{
-				Name:   aws.String("group-name"),
-				Values: []*string{&name},
+	res, err := svc.DescribeSecurityGroups(
+		&ec2.DescribeSecurityGroupsInput{
+			Filters: []*ec2.Filter{
+				&ec2.Filter{
+					Name:   aws.String("group-name"),
+					Values: []*string{&name},
+				},
 			},
-		},
-	}
-	res, err := svc.DescribeSecurityGroups(params)
+		})
 	if err != nil {
 		log.Panic(err.Error())
 	}
@@ -214,6 +214,11 @@ func FindSGByName(name string, vpc string, svc ec2iface.EC2API) (ret []string) {
 // Init initializes connection to AWS API
 func Init() ec2iface.EC2API {
 	region := "us-east-1"
-	sess := session.New(&aws.Config{Region: aws.String(region)})
-	return ec2.New(sess)
+	return ec2.New(
+		session.New(
+			&aws.Config{
+				Region: aws.String(region),
+			},
+		),
+	)
 }

--- a/mcc/capcom/capcom/capcom.go
+++ b/mcc/capcom/capcom/capcom.go
@@ -46,7 +46,7 @@ func AuthorizeAccessToSecurityGroup(
 	svc ec2iface.EC2API,
 	perm *ec2.IpPermission,
 	destination string,
-) *ec2.AuthorizeSecurityGroupIngressOutput {
+) bool {
 	out, error := svc.AuthorizeSecurityGroupIngress(
 		&ec2.AuthorizeSecurityGroupIngressInput{
 			GroupId:       &destination,
@@ -55,7 +55,10 @@ func AuthorizeAccessToSecurityGroup(
 	if error != nil {
 		log.Panic(error)
 	}
-	return out
+	if !(out != nil) {
+		return false
+	}
+	return true
 }
 
 // RevokeAccessToSecurityGroup adds the specified permissions to the Ingress
@@ -64,7 +67,7 @@ func RevokeAccessToSecurityGroup(
 	svc ec2iface.EC2API,
 	perm *ec2.IpPermission,
 	destination string,
-) *ec2.RevokeSecurityGroupIngressOutput {
+) bool {
 	out, error := svc.RevokeSecurityGroupIngress(
 		&ec2.RevokeSecurityGroupIngressInput{
 			GroupId:       &destination,
@@ -73,7 +76,10 @@ func RevokeAccessToSecurityGroup(
 	if error != nil {
 		log.Panic(error)
 	}
-	return out
+	if !(out != nil) {
+		return false
+	}
+	return true
 }
 
 // FindSecurityGroupsWithRange returns a list of SGIDs where the CIDR

--- a/mcc/capcom/capcom/capcom.go
+++ b/mcc/capcom/capcom/capcom.go
@@ -89,6 +89,7 @@ func FindSecurityGroupsWithRange(
 	searchIP, _, err := net.ParseCIDR(cidr)
 	if err != nil {
 		err = fmt.Errorf("%s is not a valid CIDR\n", cidr)
+		return
 	}
 	// Obtain and traverse AWS's Security Group structure
 	for _, sg := range getSecurityGroups(svc).SecurityGroups {

--- a/mcc/capcom/capcom/capcom_test.go
+++ b/mcc/capcom/capcom/capcom_test.go
@@ -5,73 +5,7 @@ import (
 	"fmt"
 	"net"
 	"testing"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
-
-type mockEC2Client struct {
-	ec2iface.EC2API
-}
-
-func (m *mockEC2Client) AuthorizeSecurityGroupIngress(
-	params *ec2.AuthorizeSecurityGroupIngressInput,
-) (
-	out *ec2.AuthorizeSecurityGroupIngressOutput,
-	err error,
-) {
-	return
-}
-
-func (m *mockEC2Client) CreateSecurityGroup(
-	params *ec2.CreateSecurityGroupInput,
-) (
-	out *ec2.CreateSecurityGroupOutput,
-	err error,
-) {
-	err = params.Validate()
-	out = &ec2.CreateSecurityGroupOutput{
-		GroupId: aws.String("sg-12345678"),
-	}
-	return
-}
-
-func (m *mockEC2Client) DescribeSecurityGroups(
-	in *ec2.DescribeSecurityGroupsInput,
-) (
-	out *ec2.DescribeSecurityGroupsOutput,
-	err error,
-) {
-	out = &ec2.DescribeSecurityGroupsOutput{
-		SecurityGroups: []*ec2.SecurityGroup{
-			{
-				Description: aws.String(""),
-				GroupId:     aws.String("sg-1234"),
-				GroupName:   aws.String(""),
-				IpPermissions: []*ec2.IpPermission{
-					{
-						IpProtocol: aws.String("tcp"),
-						ToPort:     aws.Int64(22),
-						IpRanges: []*ec2.IpRange{
-							{CidrIp: aws.String("1.2.3.4/32")},
-						},
-					},
-				},
-			},
-		},
-	}
-	return
-}
-
-func (m *mockEC2Client) RevokeSecurityGroupIngress(
-	params *ec2.RevokeSecurityGroupIngressInput,
-) (
-	out *ec2.RevokeSecurityGroupIngressOutput,
-	err error,
-) {
-	return
-}
 
 var ListSecurityGroupsExpectedOutput = []string{
 	fmt.Sprintf("* %10s %20s %s\n", "sg-1234", "", ""),

--- a/mcc/capcom/capcom/capcom_test.go
+++ b/mcc/capcom/capcom/capcom_test.go
@@ -239,3 +239,60 @@ func TestNetworkContainsIPCheck(t *testing.T) {
 		}
 	}
 }
+
+func TestAuthorizeAccessToSecurityGroup(t *testing.T) {
+	data := []struct {
+		origin, proto string
+		port          int64
+		destination   string
+		expected      bool
+	}{
+		{
+			origin:   "1.2.3.4/32",
+			proto:    "tcp",
+			port:     int64(0),
+			expected: true,
+		},
+	}
+	svc := &mockEC2Client{}
+	for _, tc := range data {
+		perm, _ := BuildIPPermission(tc.origin, tc.proto, tc.port)
+		out := AuthorizeAccessToSecurityGroup(
+			svc,
+			perm,
+			tc.destination,
+		)
+		if out != tc.expected {
+			t.Error("Unexpected mismatch")
+		}
+	}
+}
+
+func TestRevokeAccessToSecurityGroup(t *testing.T) {
+	data := []struct {
+		origin, proto string
+		port          int64
+		destination   string
+		expected      bool
+	}{
+		{
+			origin:   "1.2.3.4/32",
+			proto:    "tcp",
+			port:     int64(0),
+			expected: true,
+		},
+	}
+	svc := &mockEC2Client{}
+	for _, tc := range data {
+		perm, _ := BuildIPPermission(tc.origin, tc.proto, tc.port)
+		out := RevokeAccessToSecurityGroup(
+			svc,
+			perm,
+			tc.destination,
+		)
+		if out != tc.expected {
+			t.Error("Unexpected mismatch")
+		}
+	}
+
+}

--- a/mcc/capcom/capcom/capcom_test.go
+++ b/mcc/capcom/capcom/capcom_test.go
@@ -7,14 +7,12 @@ import (
 	"testing"
 )
 
-var ListSecurityGroupsExpectedOutput = []string{
-	fmt.Sprintf("* %10s %20s %s\n", "sg-1234", "", ""),
-}
-
 func TestListSecurityGroups(t *testing.T) {
 	svc := &mockEC2Client{}
 	out := ListSecurityGroups(svc)
-	expected := ListSecurityGroupsExpectedOutput
+	expected := []string{
+		fmt.Sprintf("* %10s %20s %s\n", "sg-1234", "", ""),
+	}
 	for index, line := range out {
 		if line != expected[index] {
 			t.Error("Unexpected output")
@@ -22,46 +20,45 @@ func TestListSecurityGroups(t *testing.T) {
 	}
 }
 
-var biptable = []struct {
-	origin string
-	proto  string
-	port   int64
-	err    error
-}{
-	{
-		origin: "1.2.3.4/32",
-		proto:  "tcp",
-		port:   int64(0),
-		err:    nil,
-	},
-	{
-		origin: "sg-",
-		proto:  "tcp",
-		port:   int64(0),
-		err:    nil,
-	},
-	{
-		origin: "1.2.3.4/32",
-		proto:  "udp",
-		port:   int64(0),
-		err:    nil,
-	},
-	{
-		origin: "sg-",
-		proto:  "icmp",
-		port:   int64(0),
-		err:    nil,
-	},
-	{
-		origin: "1.2.3./32",
-		proto:  "udp",
-		port:   int64(0),
-		err:    errors.New(""),
-	},
-}
-
 func TestBuildIPPermission(t *testing.T) {
 	for _, tt := range biptable {
+	data := []struct {
+		origin string
+		proto  string
+		port   int64
+		err    error
+	}{
+		{
+			origin: "1.2.3.4/32",
+			proto:  "tcp",
+			port:   int64(0),
+			err:    nil,
+		},
+		{
+			origin: "sg-",
+			proto:  "tcp",
+			port:   int64(0),
+			err:    nil,
+		},
+		{
+			origin: "1.2.3.4/32",
+			proto:  "udp",
+			port:   int64(0),
+			err:    nil,
+		},
+		{
+			origin: "sg-",
+			proto:  "icmp",
+			port:   int64(0),
+			err:    nil,
+		},
+		{
+			origin: "1.2.3./32",
+			proto:  "udp",
+			port:   int64(0),
+			err:    errors.New(""),
+		},
+	}
 		_, err := BuildIPPermission(
 			tt.origin,
 			tt.proto,
@@ -74,27 +71,27 @@ func TestBuildIPPermission(t *testing.T) {
 	}
 }
 
-var csgtable = []struct {
-	name        string
-	description string
-	vpcid       string
-	out         string
-}{
-	{
-		name:        "",
-		description: "Non-VPC success",
-		vpcid:       "",
-		out:         "sg-12345678",
-	},
-	{
-		name:        "",
-		description: "VPC success",
-		vpcid:       "vpc-12345678",
-		out:         "sg-12345678",
-	},
-}
-
 func TestCreateSG(t *testing.T) {
+	data := []struct {
+		name        string
+		description string
+		vpcid       string
+		out         string
+	}{
+		{
+			name:        "",
+			description: "Non-VPC success",
+			vpcid:       "",
+			out:         "sg-12345678",
+		},
+		{
+			name:        "",
+			description: "VPC success",
+			vpcid:       "vpc-12345678",
+			out:         "sg-12345678",
+		},
+	}
+
 	svc := &mockEC2Client{}
 	for _, tt := range csgtable {
 		t.Run(
@@ -114,21 +111,20 @@ func TestCreateSG(t *testing.T) {
 	}
 }
 
-var fsgbntable = []struct {
-	name string
-	vpc  string
-	ret  []string
-}{
-	{
-		name: "",
-		vpc:  "",
-		ret: []string{
-			"sg-1234",
-		},
-	},
-}
-
 func TestFindSGByName(t *testing.T) {
+	data := []struct {
+		name string
+		vpc  string
+		ret  []string
+	}{
+		{
+			name: "",
+			vpc:  "",
+			ret: []string{
+				"sg-1234",
+			},
+		},
+	}
 	svc := &mockEC2Client{}
 	for _, tt := range fsgbntable {
 		ret := FindSGByName(tt.name, tt.vpc, svc)
@@ -140,25 +136,25 @@ func TestFindSGByName(t *testing.T) {
 	}
 }
 
-var fsgwtable = []struct {
-	cidr string
-	err  error
-	ret  []SearchResult
-}{
-	{
-		cidr: "1.2.3.4/32",
-		err:  nil,
-		ret: []SearchResult{
-			SearchResult{
-				GroupID:  "sg-1234",
-				Protocol: "tcp",
-				Port:     22,
-				Source:   "1.2.3.4/32",
-			}},
-	},
-}
-
 func TestFindSecurityGroupsWithRange(t *testing.T) {
+	data := []struct {
+		cidr string
+		err  error
+		ret  []SearchResult
+	}{
+		{
+			cidr: "1.2.3.4/32",
+			err:  nil,
+			ret: []SearchResult{
+				SearchResult{
+					GroupID:  "sg-1234",
+					Protocol: "tcp",
+					Port:     22,
+					Source:   "1.2.3.4/32",
+				}},
+		},
+	}
+
 	svc := &mockEC2Client{}
 	for _, tt := range fsgwtable {
 		ret, err := FindSecurityGroupsWithRange(svc, tt.cidr)
@@ -181,62 +177,61 @@ func TestFindSecurityGroupsWithRange(t *testing.T) {
 	}
 }
 
-var ncictable = []struct {
-	cidr string
-	ip   string
-	ret  bool
-	err  error
-}{
-	{
-		cidr: "0.0.0.0/0",
-		ip:   "1.2.3.4/32",
-		ret:  true,
-		err:  nil,
-	},
-	{
-		cidr: "deadbeef",
-		ip:   "1.2.3.4/32",
-		ret:  false,
-		err:  errors.New(""),
-	},
-	{
-		cidr: "192.168.1.0/24",
-		ip:   "192.168.1.1/32",
-		ret:  true,
-		err:  nil,
-	},
-	{
-		cidr: "192.168.1.0/24",
-		ip:   "192.168.3.1/32",
-		ret:  false,
-		err:  nil,
-	},
-	{
-		cidr: "192.168.1.0/24",
-		ip:   "192.168.1.0/24",
-		ret:  true,
-		err:  nil,
-	},
-	{
-		cidr: "192.168.1.0/24",
-		ip:   "192.168.3.0/24",
-		ret:  false,
-		err:  nil,
-	},
-	{
-		cidr: "192.168.0.0/16",
-		ip:   "192.168.10.0/24",
-		ret:  true,
-		err:  nil,
-	},
-}
-
 func TestNetworkContainsIPCheck(t *testing.T) {
 	for _, tt := range ncictable {
 		ip, _, _ := net.ParseCIDR(tt.ip)
 		ret, err := NetworkContainsIPCheck(tt.cidr, ip)
 		if (err != nil && tt.err == nil) ||
 			(err == nil && tt.err != nil) {
+	data := []struct {
+		cidr string
+		ip   string
+		ret  bool
+		err  error
+	}{
+		{
+			cidr: "0.0.0.0/0",
+			ip:   "1.2.3.4/32",
+			ret:  true,
+			err:  nil,
+		},
+		{
+			cidr: "deadbeef",
+			ip:   "1.2.3.4/32",
+			ret:  false,
+			err:  errors.New(""),
+		},
+		{
+			cidr: "192.168.1.0/24",
+			ip:   "192.168.1.1/32",
+			ret:  true,
+			err:  nil,
+		},
+		{
+			cidr: "192.168.1.0/24",
+			ip:   "192.168.3.1/32",
+			ret:  false,
+			err:  nil,
+		},
+		{
+			cidr: "192.168.1.0/24",
+			ip:   "192.168.1.0/24",
+			ret:  true,
+			err:  nil,
+		},
+		{
+			cidr: "192.168.1.0/24",
+			ip:   "192.168.3.0/24",
+			ret:  false,
+			err:  nil,
+		},
+		{
+			cidr: "192.168.0.0/16",
+			ip:   "192.168.10.0/24",
+			ret:  true,
+			err:  nil,
+		},
+	}
 			t.Error("Unexpected/mismatched error")
 		}
 		if ret != tt.ret {

--- a/mcc/capcom/capcom/capcom_test.go
+++ b/mcc/capcom/capcom/capcom_test.go
@@ -21,7 +21,6 @@ func TestListSecurityGroups(t *testing.T) {
 }
 
 func TestBuildIPPermission(t *testing.T) {
-	for _, tt := range biptable {
 	data := []struct {
 		origin string
 		proto  string
@@ -59,13 +58,14 @@ func TestBuildIPPermission(t *testing.T) {
 			err:    errors.New(""),
 		},
 	}
+	for _, tc := range data {
 		_, err := BuildIPPermission(
-			tt.origin,
-			tt.proto,
-			tt.port,
+			tc.origin,
+			tc.proto,
+			tc.port,
 		)
-		if (err != nil && tt.err == nil) ||
-			(err == nil && tt.err != nil) {
+		if (err != nil && tc.err == nil) ||
+			(err == nil && tc.err != nil) {
 			t.Error(err)
 		}
 	}
@@ -93,17 +93,17 @@ func TestCreateSG(t *testing.T) {
 	}
 
 	svc := &mockEC2Client{}
-	for _, tt := range csgtable {
+	for _, tc := range data {
 		t.Run(
-			tt.description,
+			tc.description,
 			func(t *testing.T) {
 				out := CreateSG(
-					tt.name,
-					tt.description,
-					tt.vpcid,
+					tc.name,
+					tc.description,
+					tc.vpcid,
 					svc,
 				)
-				if out != tt.out {
+				if out != tc.out {
 					t.Error("Unexpected output")
 				}
 			},
@@ -126,10 +126,10 @@ func TestFindSGByName(t *testing.T) {
 		},
 	}
 	svc := &mockEC2Client{}
-	for _, tt := range fsgbntable {
-		ret := FindSGByName(tt.name, tt.vpc, svc)
+	for _, tc := range data {
+		ret := FindSGByName(tc.name, tc.vpc, svc)
 		for index := range ret {
-			if ret[index] != tt.ret[index] {
+			if ret[index] != tc.ret[index] {
 				t.Error("Unexpected output")
 			}
 		}
@@ -156,21 +156,21 @@ func TestFindSecurityGroupsWithRange(t *testing.T) {
 	}
 
 	svc := &mockEC2Client{}
-	for _, tt := range fsgwtable {
-		ret, err := FindSecurityGroupsWithRange(svc, tt.cidr)
-		if (err != nil && tt.err == nil) ||
-			(err == nil && tt.err != nil) {
+	for _, tc := range data {
+		ret, err := FindSecurityGroupsWithRange(svc, tc.cidr)
+		if (err != nil && tc.err == nil) ||
+			(err == nil && tc.err != nil) {
 			t.Error("Unexpected/mismatched error")
 		}
-		if len(ret) != len(tt.ret) {
+		if len(ret) != len(tc.ret) {
 			t.Error("Mismatched results and expectations length")
 		}
 		for k, v := range ret {
-			if v.String() != tt.ret[k].String() {
+			if v.String() != tc.ret[k].String() {
 				t.Errorf(
 					"Unexpected output %s != %s",
 					v.String(),
-					tt.ret[k].String(),
+					tc.ret[k].String(),
 				)
 			}
 		}
@@ -178,11 +178,6 @@ func TestFindSecurityGroupsWithRange(t *testing.T) {
 }
 
 func TestNetworkContainsIPCheck(t *testing.T) {
-	for _, tt := range ncictable {
-		ip, _, _ := net.ParseCIDR(tt.ip)
-		ret, err := NetworkContainsIPCheck(tt.cidr, ip)
-		if (err != nil && tt.err == nil) ||
-			(err == nil && tt.err != nil) {
 	data := []struct {
 		cidr string
 		ip   string
@@ -232,9 +227,14 @@ func TestNetworkContainsIPCheck(t *testing.T) {
 			err:  nil,
 		},
 	}
+	for _, tc := range data {
+		ip, _, _ := net.ParseCIDR(tc.ip)
+		ret, err := NetworkContainsIPCheck(tc.cidr, ip)
+		if (err != nil && tc.err == nil) ||
+			(err == nil && tc.err != nil) {
 			t.Error("Unexpected/mismatched error")
 		}
-		if ret != tt.ret {
+		if ret != tc.ret {
 			t.Error("Unexpected mismatch")
 		}
 	}

--- a/mcc/capcom/capcom/doc.go
+++ b/mcc/capcom/capcom/doc.go
@@ -1,0 +1,3 @@
+// Package capcom provides methods to interact with AWS's Security
+// Groups and their rules.
+package capcom

--- a/mcc/capcom/capcom/ec2mock_test.go
+++ b/mcc/capcom/capcom/ec2mock_test.go
@@ -13,10 +13,10 @@ type mockEC2Client struct {
 func (m *mockEC2Client) AuthorizeSecurityGroupIngress(
 	params *ec2.AuthorizeSecurityGroupIngressInput,
 ) (
-	out *ec2.AuthorizeSecurityGroupIngressOutput,
-	err error,
+	*ec2.AuthorizeSecurityGroupIngressOutput,
+	error,
 ) {
-	return
+	return &ec2.AuthorizeSecurityGroupIngressOutput{}, nil
 }
 
 func (m *mockEC2Client) CreateSecurityGroup(
@@ -62,8 +62,8 @@ func (m *mockEC2Client) DescribeSecurityGroups(
 func (m *mockEC2Client) RevokeSecurityGroupIngress(
 	params *ec2.RevokeSecurityGroupIngressInput,
 ) (
-	out *ec2.RevokeSecurityGroupIngressOutput,
-	err error,
+	*ec2.RevokeSecurityGroupIngressOutput,
+	error,
 ) {
-	return
+	return &ec2.RevokeSecurityGroupIngressOutput{}, nil
 }

--- a/mcc/capcom/capcom/ec2mock_test.go
+++ b/mcc/capcom/capcom/ec2mock_test.go
@@ -1,0 +1,69 @@
+package capcom
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+)
+
+type mockEC2Client struct {
+	ec2iface.EC2API
+}
+
+func (m *mockEC2Client) AuthorizeSecurityGroupIngress(
+	params *ec2.AuthorizeSecurityGroupIngressInput,
+) (
+	out *ec2.AuthorizeSecurityGroupIngressOutput,
+	err error,
+) {
+	return
+}
+
+func (m *mockEC2Client) CreateSecurityGroup(
+	params *ec2.CreateSecurityGroupInput,
+) (
+	out *ec2.CreateSecurityGroupOutput,
+	err error,
+) {
+	err = params.Validate()
+	out = &ec2.CreateSecurityGroupOutput{
+		GroupId: aws.String("sg-12345678"),
+	}
+	return
+}
+
+func (m *mockEC2Client) DescribeSecurityGroups(
+	in *ec2.DescribeSecurityGroupsInput,
+) (
+	out *ec2.DescribeSecurityGroupsOutput,
+	err error,
+) {
+	out = &ec2.DescribeSecurityGroupsOutput{
+		SecurityGroups: []*ec2.SecurityGroup{
+			{
+				Description: aws.String(""),
+				GroupId:     aws.String("sg-1234"),
+				GroupName:   aws.String(""),
+				IpPermissions: []*ec2.IpPermission{
+					{
+						IpProtocol: aws.String("tcp"),
+						ToPort:     aws.Int64(22),
+						IpRanges: []*ec2.IpRange{
+							{CidrIp: aws.String("1.2.3.4/32")},
+						},
+					},
+				},
+			},
+		},
+	}
+	return
+}
+
+func (m *mockEC2Client) RevokeSecurityGroupIngress(
+	params *ec2.RevokeSecurityGroupIngressInput,
+) (
+	out *ec2.RevokeSecurityGroupIngressOutput,
+	err error,
+) {
+	return
+}

--- a/mcc/capcom/cmd/add.go
+++ b/mcc/capcom/cmd/add.go
@@ -33,10 +33,23 @@ string) to the specified port. E.g.:
 			if err != nil {
 				log.Fatal(err)
 			}
-			_ = capcom.AuthorizeAccessToSecurityGroup(
+			if !capcom.AuthorizeAccessToSecurityGroup(
 				svc,
 				perm,
 				sgid,
+			) {
+				log.Fatalf("Failed to add rule to %s: %s %s %d\n",
+					sgid,
+					source,
+					proto,
+					port,
+				)
+			}
+			log.Printf("Rule added successfully to %s: %s %s %d\n",
+				sgid,
+				source,
+				proto,
+				port,
 			)
 		}
 	},

--- a/mcc/capcom/cmd/revoke.go
+++ b/mcc/capcom/cmd/revoke.go
@@ -30,10 +30,23 @@ string) to the specified port. E.g.:
 			if err != nil {
 				log.Fatal(err)
 			}
-			_ = capcom.RevokeAccessToSecurityGroup(
+			if !capcom.RevokeAccessToSecurityGroup(
 				svc,
 				perm,
 				sgid,
+			) {
+				log.Fatalf("Failed to remove rule to %s: %s %s %d\n",
+					sgid,
+					source,
+					proto,
+					port,
+				)
+			}
+			log.Printf("Rule removed successfully to %s: %s %s %d\n",
+				sgid,
+				source,
+				proto,
+				port,
 			)
 		}
 	},

--- a/mss/dextre/cmd/bl.go
+++ b/mss/dextre/cmd/bl.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"log"
 	"math"
+	"os"
 
 	"github.com/olorin/nagiosplugin"
 	"github.com/poka-yoke/spaceflight/mss/dextre/dnsbl"
@@ -24,7 +25,13 @@ var blCmd = &cobra.Command{
 	Short: "Check for blacklist presence",
 	Long:  `Checks the supplied list of DNS-based blacklists for a specific IP presence. It returns the results in a Nagios compliat string. Thresholds for different Nagios states can be supplied as well.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		list := dnsbl.FromFile(blacklist)
+		blfile, err := os.Open(blacklist)
+		if err != nil {
+			log.Fatal("Could't open file ", blacklist, err)
+		}
+		defer blfile.Close()
+
+		list := dnsbl.Read(blfile)
 		dnsbl.Queries(ipAddress, list)
 
 		positive := dnsbl.Stats.Positive

--- a/mss/dextre/dnsbl/dnsbl.go
+++ b/mss/dextre/dnsbl/dnsbl.go
@@ -3,9 +3,9 @@ package dnsbl
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"log"
 	"net"
-	"os"
 	"strings"
 	"sync"
 )
@@ -19,17 +19,11 @@ var Stats struct {
 	Length, Queried, Positive int
 }
 
-// FromFile reads a file from disk and introduces each line in a channel
-func FromFile(path string) <-chan string {
+// Read introduces each line from io.Reader in a channel
+func Read(in io.Reader) <-chan string {
 	out := make(chan string)
 	go func() {
-		blfile, err := os.Open(path)
-		if err != nil {
-			log.Fatal("Could't open file ", path, err)
-		}
-		defer blfile.Close()
-
-		scanner := bufio.NewScanner(blfile)
+		scanner := bufio.NewScanner(in)
 		for scanner.Scan() {
 			wg.Add(1)
 			out <- scanner.Text()


### PR DESCRIPTION
Results from a hackathon improving tests for DotGo 2017. Kinda overdue.

**Improved interface of dnsbl blacklist import**

**Reorder functions due to importance**

**Add missing return on error**

**Create struct in place instead of field by field**

**Use inline struct as param directly**

**Add package docs**

**Split mock code into own file**

**Improve BuildIPPermission's validation check**

**Move test tables into test functions**

**Rename tt to tc: test case**

**Improve Authorize and Revoke SG Mock functions**

**Improve Authorize and Revoke return value**
The original structure returned has no fields and provides no real
information on the aoperation. Substituting it by a bool informs on
the operation's success or failure without need to handle the errors.

**Use the new return values and report success/failure**
