### PR TITLE
Refactor dnsbl package for future use

### DIFF
--- a/cmd/dextre/cmd/bl.go
+++ b/cmd/dextre/cmd/bl.go
@@ -32,7 +32,8 @@ var blCmd = &cobra.Command{
 		}
 		defer blfile.Close()
 
-		dnsbl.Query(ipAddress, blfile)
+		checker := dnsbl.NewChecker()
+		checker.Query(ipAddress, blfile)
 
 		positive := dnsbl.Stats.Positive
 		queried := dnsbl.Stats.Queried

--- a/cmd/dextre/cmd/bl.go
+++ b/cmd/dextre/cmd/bl.go
@@ -32,9 +32,7 @@ var blCmd = &cobra.Command{
 		}
 		defer blfile.Close()
 
-		checker := dnsbl.NewChecker()
-		checker.Query(ipAddress, blfile)
-		positive, queried, length := checker.Stats()
+		positive, queried, length := dnsbl.NewChecker().Query(ipAddress, blfile).Stats()
 
 		check := nagiosplugin.NewCheck()
 		defer check.Finish()

--- a/cmd/dextre/cmd/bl.go
+++ b/cmd/dextre/cmd/bl.go
@@ -35,9 +35,9 @@ var blCmd = &cobra.Command{
 		checker := dnsbl.NewChecker()
 		checker.Query(ipAddress, blfile)
 
-		positive := dnsbl.Stats.Positive
-		queried := dnsbl.Stats.Queried
-		length := dnsbl.Stats.Length
+		positive := checker.Positive
+		queried := checker.Queried
+		length := checker.Length
 
 		check := nagiosplugin.NewCheck()
 		defer check.Finish()

--- a/cmd/dextre/cmd/bl.go
+++ b/cmd/dextre/cmd/bl.go
@@ -34,10 +34,7 @@ var blCmd = &cobra.Command{
 
 		checker := dnsbl.NewChecker()
 		checker.Query(ipAddress, blfile)
-
-		positive := checker.Positive
-		queried := checker.Queried
-		length := checker.Length
+		positive, queried, length := checker.Stats()
 
 		check := nagiosplugin.NewCheck()
 		defer check.Finish()

--- a/cmd/dextre/cmd/bl.go
+++ b/cmd/dextre/cmd/bl.go
@@ -32,8 +32,7 @@ var blCmd = &cobra.Command{
 		}
 		defer blfile.Close()
 
-		list := dnsbl.Read(blfile)
-		dnsbl.Queries(ipAddress, list)
+		dnsbl.Query(ipAddress, blfile)
 
 		positive := dnsbl.Stats.Positive
 		queried := dnsbl.Stats.Queried

--- a/cmd/dextre/cmd/sidekiq.go
+++ b/cmd/dextre/cmd/sidekiq.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"log"
-	"strings"
 
 	"github.com/spf13/cobra"
 

--- a/pkg/dnsbl/dnsbl.go
+++ b/pkg/dnsbl/dnsbl.go
@@ -28,7 +28,7 @@ func NewChecker() *Checker {
 
 // Query handles concurrency for Query. WaitGroup elements are added
 // when reading the input
-func (c *Checker) Query(ipAddress string, lists io.Reader) {
+func (c *Checker) Query(ipAddress string, lists io.Reader) *Checker {
 	list := c.read(lists)
 	responses := make(chan int)
 	for l := range list {
@@ -44,6 +44,7 @@ func (c *Checker) Query(ipAddress string, lists io.Reader) {
 	}()
 	c.wg.Wait()
 	close(responses)
+	return c
 }
 
 // Stats returns the number of positive results along with the amount

--- a/pkg/dnsbl/dnsbl.go
+++ b/pkg/dnsbl/dnsbl.go
@@ -19,9 +19,9 @@ var Stats struct {
 	Length, Queried, Positive int
 }
 
-// Queries handles concurrency for Query. WaitGroup elements are added
+// Query handles concurrency for Query. WaitGroup elements are added
 // when reading the input
-func Queries(ipAddress string, lists io.Reader) {
+func Query(ipAddress string, lists io.Reader) {
 	list := read(lists)
 	responses := make(chan int)
 	for l := range list {

--- a/pkg/dnsbl/dnsbl.go
+++ b/pkg/dnsbl/dnsbl.go
@@ -35,7 +35,7 @@ func Read(in io.Reader) <-chan string {
 }
 
 // Reverse reverses slice of string elements.
-func Reverse(original []string) {
+func reverse(original []string) {
 	for i := len(original)/2 - 1; i >= 0; i-- {
 		opp := len(original) - 1 - i
 		original[i], original[opp] = original[opp], original[i]
@@ -43,19 +43,19 @@ func Reverse(original []string) {
 }
 
 // ReverseAddress converts IP address in string to reversed address for query.
-func ReverseAddress(ipAddress string) (reversedIPAddress string) {
+func reverseAddress(ipAddress string) (reversedIPAddress string) {
 	ipAddressValues := strings.Split(ipAddress, ".")
-	Reverse(ipAddressValues)
+	reverse(ipAddressValues)
 	reversedIPAddress = strings.Join(ipAddressValues, ".")
 	return
 }
 
 // Query queries a DNSBL and returns true if the argument gets a match
 // in the BL.
-func Query(ipAddress, bl string, addresses chan<- int) {
+func query(ipAddress, bl string, addresses chan<- int) {
 	reversedIPAddress := fmt.Sprintf(
 		"%v.%v",
-		ReverseAddress(ipAddress),
+		reverseAddress(ipAddress),
 		bl,
 	)
 	result, _ := Lookup(reversedIPAddress)
@@ -71,7 +71,7 @@ func Query(ipAddress, bl string, addresses chan<- int) {
 func Queries(ipAddress string, list <-chan string) {
 	responses := make(chan int)
 	for l := range list {
-		go Query(ipAddress, l, responses)
+		go query(ipAddress, l, responses)
 	}
 	go func() {
 		for response := range responses {

--- a/pkg/dnsbl/dnsbl.go
+++ b/pkg/dnsbl/dnsbl.go
@@ -10,22 +10,21 @@ import (
 	"sync"
 )
 
-// Lookup contains the lookup function used
-var Lookup = net.LookupHost
-
 // Checker controls the flow of package and provides a single point of
 // entry for its users.
 type Checker struct {
 	// Public members
 	Length, Queried, Positive int
 
+	// lookup contains the lookup function used
+	lookup func(string) ([]string, error)
 	// Functional control
 	wg sync.WaitGroup
 }
 
 // NewChecker creates a new, default configured Checker
 func NewChecker() *Checker {
-	return &Checker{}
+	return &Checker{lookup: net.LookupHost}
 }
 
 // Query handles concurrency for Query. WaitGroup elements are added
@@ -71,7 +70,7 @@ func (c *Checker) query(ipAddress, bl string, addresses chan<- int) {
 		reverseAddress(ipAddress),
 		bl,
 	)
-	result, _ := Lookup(reversedIPAddress)
+	result, _ := c.lookup(reversedIPAddress)
 	if len(result) > 0 {
 		log.Printf("%v present in %v(%v)", reversedIPAddress, bl, result)
 	}

--- a/pkg/dnsbl/dnsbl_test.go
+++ b/pkg/dnsbl/dnsbl_test.go
@@ -51,9 +51,10 @@ func mockLookup(blacklist string) (addresses []string, err error) {
 
 func TestQuery(t *testing.T) {
 	Lookup = mockLookup
+	checker := &Checker{}
 	results := make(chan int)
 	t.Log("Hola")
-	go query("127.0.0.1", "positive.dnsbl.com", results)
+	go checker.query("127.0.0.1", "positive.dnsbl.com", results)
 	result := <-results
 	if result != 1 {
 		t.Errorf(
@@ -62,7 +63,7 @@ func TestQuery(t *testing.T) {
 			result,
 		)
 	}
-	go query("127.0.0.1", "negative.dnsbl.com", results)
+	go checker.query("127.0.0.1", "negative.dnsbl.com", results)
 	result = <-results
 	if result != 0 {
 		t.Errorf(

--- a/pkg/dnsbl/dnsbl_test.go
+++ b/pkg/dnsbl/dnsbl_test.go
@@ -8,7 +8,7 @@ func TestReverse(t *testing.T) {
 		"2",
 		"3",
 	}
-	Reverse(stringSlice)
+	reverse(stringSlice)
 	if stringSlice[0] != "3" {
 		t.Errorf(
 			"stringSlice[0] should be 3 and not %s",
@@ -31,7 +31,7 @@ func TestReverse(t *testing.T) {
 
 func TestReverseAddress(t *testing.T) {
 	ipAddress := "127.0.0.1"
-	reversedIPAddress := ReverseAddress(ipAddress)
+	reversedIPAddress := reverseAddress(ipAddress)
 	if reversedIPAddress != "1.0.0.127" {
 		t.Errorf(
 			"reversedIPAddress should be 1.0.0.127 and not %s",
@@ -53,7 +53,7 @@ func TestQuery(t *testing.T) {
 	Lookup = mockLookup
 	results := make(chan int)
 	t.Log("Hola")
-	go Query("127.0.0.1", "positive.dnsbl.com", results)
+	go query("127.0.0.1", "positive.dnsbl.com", results)
 	result := <-results
 	if result != 1 {
 		t.Errorf(
@@ -62,7 +62,7 @@ func TestQuery(t *testing.T) {
 			result,
 		)
 	}
-	go Query("127.0.0.1", "negative.dnsbl.com", results)
+	go query("127.0.0.1", "negative.dnsbl.com", results)
 	result = <-results
 	if result != 0 {
 		t.Errorf(

--- a/pkg/dnsbl/dnsbl_test.go
+++ b/pkg/dnsbl/dnsbl_test.go
@@ -50,8 +50,7 @@ func mockLookup(blacklist string) (addresses []string, err error) {
 }
 
 func TestQuery(t *testing.T) {
-	Lookup = mockLookup
-	checker := &Checker{}
+	checker := &Checker{lookup: mockLookup}
 	results := make(chan int)
 	t.Log("Hola")
 	go checker.query("127.0.0.1", "positive.dnsbl.com", results)


### PR DESCRIPTION
We want to create a Prometheus exporter for the `dnsbl` functionality. Cleaning up the package design and providing a clean interface for it should also help to reuse it for more use cases. Tests need to be reviewed as well to ensure main functionality is covered, though properly testing it probably requires building a faker properly, which could become quite big, unless we find one to simply reuse.

Next PR will be focusing on making `sidekiq` package also up-to-date so we can build the exporter.

**Fix building dextre command**
The strings package had been left over and causing compilation failed.

**Unexport internal functions**
They are not needed outside the package, so keep them private.

**Make Queries the only public method**
Remove the clunky interface between loading the addresses and querying
them.

**Rename Queries to Query**

**Add Checker struct to control package**
Make a Checker struct to hide global synchronization variables and
provide single point of entry to the package main use.

**Absorb Stats into Checker**
Provide single public struct for the package respecting previous
API. This required making query be a method of Checker as well.

**Make Lookup an internal config option of Checker**
Lookup is actually a convenince for testing. We should have a better
approach but for now, let's just hide it underneath.

**Provide public Stats method to get stats**
And make the members private so they can't be altered by a user of the package.

**Make Query chainable**
By returning the `Checker` pointer in `Query` we can chain it with
Stats and have it all become a single statement for our users.