### PR TITLE
Further dnsbl refactor

### DIFF
--- a/pkg/dnsbl/dnsbl.go
+++ b/pkg/dnsbl/dnsbl.go
@@ -36,9 +36,8 @@ func (c *Checker) Query(ipAddress string, lists io.Reader) *Checker {
 	}
 	go func() {
 		for response := range responses {
-			if response > 0 {
-				c.positive += response
-			}
+			c.positive += response
+			c.queried++
 			c.wg.Done()
 		}
 	}()
@@ -81,7 +80,6 @@ func (c *Checker) query(ipAddress, bl string, addresses chan<- int) {
 		log.Printf("%v present in %v(%v)", reversedIPAddress, bl, result)
 	}
 	addresses <- len(result)
-	c.queried++
 }
 
 // Reverse reverses slice of string elements.

--- a/pkg/dnsbl/dnsbl_test.go
+++ b/pkg/dnsbl/dnsbl_test.go
@@ -50,26 +50,29 @@ func mockLookup(blacklist string) (addresses []string, err error) {
 }
 
 func TestQuery(t *testing.T) {
+	var table = []struct {
+		query  string
+		result int
+	}{
+		{
+			query:  "1.0.0.127.positive.dnsbl.com",
+			result: 1,
+		},
+		{
+			query:  "1.0.0.127.negative.dnsbl.com",
+			result: 0,
+		},
+	}
 	checker := &Checker{lookup: mockLookup}
-	results := make(chan int)
-	t.Log("Hola")
-	go checker.query("127.0.0.1", "positive.dnsbl.com", results)
-	result := <-results
-	if result != 1 {
-		t.Errorf(
-			"Result for 1.0.0.127.positive.dnsbl.com "+
-				"should be 1 instead of %v",
-			result,
-		)
+	for _, tc := range table {
+		result := checker.query(tc.query)
+		if result != tc.result {
+			t.Errorf(
+				"Result for %s should be %d instead of %d",
+				tc.query,
+				tc.result,
+				result,
+			)
+		}
 	}
-	go checker.query("127.0.0.1", "negative.dnsbl.com", results)
-	result = <-results
-	if result != 0 {
-		t.Errorf(
-			"Result for 1.0.0.127.negative.dnsbl.com "+
-				"should be 0 instead of %v",
-			result,
-		)
-	}
-	close(results)
 }


### PR DESCRIPTION
These are the final changes to clean and simplify the `dnsbl` package. Improved testing is still pending to allow for extension in the following projects.

**Solve race condition and remove value check**
Having `queried` be incremented in the goroutines caused a race
condition where the value could be updated in several threads at the
same time losing updates. The easiest solution is to remove it from
the inside of query to put it in the response counting.

The check for response being bigger than 0 is useless as it will
always be either 0 or bigger, and adding 0 won't affect the results.

**Merge read and Query functions**
We are no longer calling read publicly and integrating the read with
the actual querying reduces complexity a bit and makes it clearer.

**Name Stats return values and improve comments**
Naming the return values from Stats makes them appear in the package
documentation to show the order of their return. Also clarify their
meaning in comments as some of them are misnomers, and clarify some of
the code decisions to ease maintainability.

**Simplify query function helper**
Remove its requirement to manage a channel whose lifetime is outside
its control and simplify the overll interface with its consumer.