### PR TITLE
DVX-6600 Create Prometheus exporter for DNSBL

### DIFF
--- a/cmd/devex_exporter/main.go
+++ b/cmd/devex_exporter/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/Devex/spaceflight/pkg/dnsbl"
+)
+
+func main() {
+	blacklist := flag.String("file", "Path to file containing black list addresses", "")
+	ipAddress := flag.String("ip", "IP Address to look for in the BLs", "127.0.0.1")
+	flag.Parse()
+
+	blfile, err := os.Open(*blacklist)
+	if err != nil {
+		log.Fatal("Could't open file ", blacklist, err)
+	}
+	defer blfile.Close()
+
+	providers := dnsbl.GetProviders(*ipAddress, blfile)
+	prometheus.MustRegister(dnsbl.NewCollector(providers))
+
+	http.Handle("/metrics", promhttp.Handler())
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/cmd/dextre/cmd/bl.go
+++ b/cmd/dextre/cmd/bl.go
@@ -32,7 +32,8 @@ var blCmd = &cobra.Command{
 		}
 		defer blfile.Close()
 
-		positive, queried, length := dnsbl.NewChecker().Query(ipAddress, blfile).Stats()
+		providers := dnsbl.GetProviders(ipAddress, blfile)
+		positive, queried, length := dnsbl.NewChecker(providers).Query().Stats()
 
 		check := nagiosplugin.NewCheck()
 		defer check.Finish()

--- a/pkg/dnsbl/collector.go
+++ b/pkg/dnsbl/collector.go
@@ -1,0 +1,98 @@
+package dnsbl
+
+import (
+	"log"
+	"net"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Collector implements a Prometheus Collector to report DNS blacklist
+// values
+type Collector struct {
+	providers               []string
+	positive, query, length prometheus.Gauge
+
+	// lookup contains the lookup function used
+	lookup func(string) ([]string, error)
+	// Functional control
+	wg sync.WaitGroup
+}
+
+// NewCollector creates a new, default configured Collector
+func NewCollector(providers []string) *Collector {
+	return &Collector{
+		lookup:    net.LookupHost,
+		providers: providers,
+		positive: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "dnsbl",
+				Name:        "positive_count",
+				Help:        "Number of positive results of DNS blacklists",
+				ConstLabels: nil,
+			},
+		),
+		query: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "dnsbl",
+				Name:        "query_count",
+				Help:        "Number of DNS blacklists providers that answered",
+				ConstLabels: nil,
+			},
+		),
+		length: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "dnsbl",
+				Name:        "length_count",
+				Help:        "Number of DNS blacklists contacted",
+				ConstLabels: nil,
+			},
+		),
+	}
+}
+
+// Describe is a requirement for the Collector interface of Prometheus
+// that returns each exported metric's description to the Prometheus
+// middleware
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.positive.Describe(ch)
+	c.query.Describe(ch)
+	c.length.Describe(ch)
+}
+
+// Collect is a requirement for the Collector interface of Prometheus
+// that runs the queries to set the metrics values to be exported
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.runCollection()
+
+	c.positive.Collect(ch)
+	c.query.Collect(ch)
+	c.length.Collect(ch)
+}
+
+func (c *Collector) runCollection() {
+	responses := make(chan int)
+	for _, provider := range c.providers {
+		c.wg.Add(1)
+		go func(provider string) {
+			result, _ := c.lookup(provider)
+			if len(result) > 0 {
+				log.Printf("%v returned %v\n", provider, result)
+			}
+			responses <- len(result)
+		}(provider)
+	}
+	go func() {
+		c.positive.Set(0)
+		c.query.Set(0)
+		for response := range responses {
+			c.positive.Add(float64(response))
+			c.query.Inc()
+			c.wg.Done()
+		}
+	}()
+	c.length.Set(float64(len(c.providers)))
+	c.wg.Wait()
+	close(responses)
+}

--- a/pkg/dnsbl/common.go
+++ b/pkg/dnsbl/common.go
@@ -7,20 +7,21 @@ import (
 	"strings"
 )
 
-// Reverse reverses slice of string elements.
-func reverse(original []string) {
+// Reverse returns a slice of string elements in reverse order than
+// the one supplied.
+func reverse(original []string) []string {
+	copy := original
 	for i := len(original)/2 - 1; i >= 0; i-- {
 		opp := len(original) - 1 - i
-		original[i], original[opp] = original[opp], original[i]
+		copy[i], copy[opp] = original[opp], original[i]
 	}
+	return copy
 }
 
-// ReverseAddress converts IP address in string to reversed address for query.
-func reverseAddress(ipAddress string) (reversedIPAddress string) {
+// ReverseAddress converts IP address into reversed address for query.
+func reverseAddress(ipAddress string) string {
 	ipAddressValues := strings.Split(ipAddress, ".")
-	reverse(ipAddressValues)
-	reversedIPAddress = strings.Join(ipAddressValues, ".")
-	return
+	return strings.Join(reverse(ipAddressValues), ".")
 }
 
 // GetProviders returns a slice of provider addresses to check

--- a/pkg/dnsbl/common.go
+++ b/pkg/dnsbl/common.go
@@ -1,6 +1,9 @@
 package dnsbl
 
 import (
+	"bufio"
+	"fmt"
+	"io"
 	"strings"
 )
 
@@ -18,4 +21,19 @@ func reverseAddress(ipAddress string) (reversedIPAddress string) {
 	reverse(ipAddressValues)
 	reversedIPAddress = strings.Join(ipAddressValues, ".")
 	return
+}
+
+// GetProviders returns a slice of provider addresses to check
+func GetProviders(ipAddress string, lists io.Reader) (providers []string) {
+	reverseAddress := reverseAddress(ipAddress)
+	scanner := bufio.NewScanner(lists)
+	for scanner.Scan() {
+		reversedIPAddress := fmt.Sprintf(
+			"%v.%v",
+			reverseAddress,
+			scanner.Text(),
+		)
+		providers = append(providers, reversedIPAddress)
+	}
+	return providers
 }

--- a/pkg/dnsbl/common.go
+++ b/pkg/dnsbl/common.go
@@ -1,0 +1,21 @@
+package dnsbl
+
+import (
+	"strings"
+)
+
+// Reverse reverses slice of string elements.
+func reverse(original []string) {
+	for i := len(original)/2 - 1; i >= 0; i-- {
+		opp := len(original) - 1 - i
+		original[i], original[opp] = original[opp], original[i]
+	}
+}
+
+// ReverseAddress converts IP address in string to reversed address for query.
+func reverseAddress(ipAddress string) (reversedIPAddress string) {
+	ipAddressValues := strings.Split(ipAddress, ".")
+	reverse(ipAddressValues)
+	reversedIPAddress = strings.Join(ipAddressValues, ".")
+	return
+}

--- a/pkg/dnsbl/common_test.go
+++ b/pkg/dnsbl/common_test.go
@@ -1,0 +1,41 @@
+package dnsbl
+
+import "testing"
+
+func TestReverse(t *testing.T) {
+	stringSlice := []string{
+		"1",
+		"2",
+		"3",
+	}
+	reverse(stringSlice)
+	if stringSlice[0] != "3" {
+		t.Errorf(
+			"stringSlice[0] should be 3 and not %s",
+			stringSlice[0],
+		)
+	}
+	if stringSlice[1] != "2" {
+		t.Errorf(
+			"stringSlice[1] should be 2 and not %s",
+			stringSlice[1],
+		)
+	}
+	if stringSlice[2] != "1" {
+		t.Errorf(
+			"stringSlice[2] should be 1 and not %s",
+			stringSlice[2],
+		)
+	}
+}
+
+func TestReverseAddress(t *testing.T) {
+	ipAddress := "127.0.0.1"
+	reversedIPAddress := reverseAddress(ipAddress)
+	if reversedIPAddress != "1.0.0.127" {
+		t.Errorf(
+			"reversedIPAddress should be 1.0.0.127 and not %s",
+			reversedIPAddress,
+		)
+	}
+}

--- a/pkg/dnsbl/dnsbl.go
+++ b/pkg/dnsbl/dnsbl.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"net"
-	"strings"
 	"sync"
 )
 
@@ -78,20 +77,4 @@ func (c *Checker) query(address string) int {
 		log.Printf("%v returned %v\n", address, result)
 	}
 	return len(result)
-}
-
-// Reverse reverses slice of string elements.
-func reverse(original []string) {
-	for i := len(original)/2 - 1; i >= 0; i-- {
-		opp := len(original) - 1 - i
-		original[i], original[opp] = original[opp], original[i]
-	}
-}
-
-// ReverseAddress converts IP address in string to reversed address for query.
-func reverseAddress(ipAddress string) (reversedIPAddress string) {
-	ipAddressValues := strings.Split(ipAddress, ".")
-	reverse(ipAddressValues)
-	reversedIPAddress = strings.Join(ipAddressValues, ".")
-	return
 }

--- a/pkg/dnsbl/dnsbl_test.go
+++ b/pkg/dnsbl/dnsbl_test.go
@@ -2,44 +2,6 @@ package dnsbl
 
 import "testing"
 
-func TestReverse(t *testing.T) {
-	stringSlice := []string{
-		"1",
-		"2",
-		"3",
-	}
-	reverse(stringSlice)
-	if stringSlice[0] != "3" {
-		t.Errorf(
-			"stringSlice[0] should be 3 and not %s",
-			stringSlice[0],
-		)
-	}
-	if stringSlice[1] != "2" {
-		t.Errorf(
-			"stringSlice[1] should be 2 and not %s",
-			stringSlice[1],
-		)
-	}
-	if stringSlice[2] != "1" {
-		t.Errorf(
-			"stringSlice[2] should be 1 and not %s",
-			stringSlice[2],
-		)
-	}
-}
-
-func TestReverseAddress(t *testing.T) {
-	ipAddress := "127.0.0.1"
-	reversedIPAddress := reverseAddress(ipAddress)
-	if reversedIPAddress != "1.0.0.127" {
-		t.Errorf(
-			"reversedIPAddress should be 1.0.0.127 and not %s",
-			reversedIPAddress,
-		)
-	}
-}
-
 func mockLookup(blacklist string) (addresses []string, err error) {
 	if blacklist == "1.0.0.127.positive.dnsbl.com" {
 		addresses = []string{"127.0.0.1"}


### PR DESCRIPTION
This creates a devex_exporter that provides DNS blacklist metrics used to verify if a certain IP is considered a source of spam. The exporter should be extensible to include other providers as well in the future.

There are some minor changes to the interface of `dnsbl` to make it more similar to the design of the Collector. This should allow to create a common resource for both `Checker` and `Collector` to reuse logic and tests were possible.

~It's still work In Progress as there's a potential race condition on startup I'm still researching~.

**DVX-6600 Move common functions to its own file**
And also move its tests.

**DVX-6600 Split provider generation from query**
Extract the generation of provider addresses from the Query function
so it can be reused.

**DVX-6600 Add devex_exporter using dnsbl.Collector**
`dnsbl.Collector` is a Prometheus Collector compliant struct based off
the `dnsbl.Checker` to collect all dnsbl metrics.

`devex_exporter` is a Prometheus exporter that exposes
`dnsbl.Collector` metrics for scraping. It's intended to be extended
to provide other package metrics as well in the future.

**DVX-6600 Improve signature for internal helpers**
Make `reverse` return a copy of the slice instead of modifying it in
place. This allows for method chaining in `reverseAddress`.

There is no need for a named return value in
`reverseAddress`. Removing it shortens the function a bit and makes it clearer.