### PR TITLE
DVX-7220 Add cloudinary subcommand to dextre

### DIFF
--- a/cmd/dextre/cmd/cloudinary.go
+++ b/cmd/dextre/cmd/cloudinary.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"log"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus/push"
+	"github.com/spf13/cobra"
+
+	"github.com/poka-yoke/spaceflight/pkg/cloudinary"
+)
+
+// cloudinaryCmd represents the cloudinary command
+var cloudinaryCmd = &cobra.Command{
+	Use:   "cloudinary",
+	Short: "Get cloudinary metrics",
+	Long:  `Gets the cloudinary usage metrics from the Admin API and returns the results in a Nagios compliant string. Thresholds for different Nagios states can be supplied as well.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		must(cloudinary.NewCredentials(
+			os.Getenv("CLOUDINARY_CLOUD_NAME"),
+			os.Getenv("CLOUDINARY_KEY"),
+			os.Getenv("CLOUDINARY_SECRET"),
+		))
+
+		if pgaddress == "" {
+			log.Fatal("pgaddress is mandatory")
+		}
+		err := push.New(pgaddress, "cloudinary").
+			Collector(cloudinary.NewCollector()).Push()
+
+		if err != nil {
+			log.Fatal("Could not push completion time to Pushgateway: ", err)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(cloudinaryCmd)
+
+	cloudinaryCmd.Flags().StringVarP(
+		&pgaddress,
+		"push-gateway",
+		"p",
+		"",
+		"Address of the Prometheus PushGateway to send results to.",
+	)
+}

--- a/pkg/cloudinary/collector.go
+++ b/pkg/cloudinary/collector.go
@@ -1,0 +1,227 @@
+package cloudinary
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Collector implements a Prometheus Collector to collect
+// Cloudinary Usage Report statistics.
+type Collector struct {
+	transformationsUsageAmount prometheus.Gauge
+	transformationsLimitAmount prometheus.Gauge
+	transformationsUsageRatio  prometheus.Gauge
+	objectsUsageAmount         prometheus.Gauge
+	objectsLimitAmount         prometheus.Gauge
+	objectsUsageRatio          prometheus.Gauge
+	bandwidthUsageBytes        prometheus.Gauge
+	bandwidthLimitBytes        prometheus.Gauge
+	bandwidthUsageRatio        prometheus.Gauge
+	storageUsageBytes          prometheus.Gauge
+	storageLimitBytes          prometheus.Gauge
+	storageUsageRatio          prometheus.Gauge
+	requestsAmount             prometheus.Gauge
+	resourcesAmount            prometheus.Gauge
+	derivedResourcesAmount     prometheus.Gauge
+}
+
+// NewCollector creates a new, default configured Collector
+func NewCollector() *Collector {
+	return &Collector{
+		transformationsUsageAmount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "transformationsUsageAmount",
+				Help:        "Number of used transformations in the last 30 days",
+				ConstLabels: nil,
+			},
+		),
+		transformationsLimitAmount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "transformationsLimitAmount",
+				Help:        "Limit of transformations allowed in the last 30 days",
+				ConstLabels: nil,
+			},
+		),
+		transformationsUsageRatio: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "transformationsUsageRatio",
+				Help:        "Ratio of used transformations over corresponding limit",
+				ConstLabels: nil,
+			},
+		),
+		objectsUsageAmount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "objectsUsageAmount",
+				Help:        "Number of used objects in the last 30 days",
+				ConstLabels: nil,
+			},
+		),
+		objectsLimitAmount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "objectsLimitAmount",
+				Help:        "Limit of objects allowed in the last 30 days",
+				ConstLabels: nil,
+			},
+		),
+		objectsUsageRatio: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "objectsUsageRatio",
+				Help:        "Ratio of used objects over corresponding limit",
+				ConstLabels: nil,
+			},
+		),
+		bandwidthUsageBytes: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "bandwidthUsageBytes",
+				Help:        "Bytes used in bandwidth in the last 30 days",
+				ConstLabels: nil,
+			},
+		),
+		bandwidthLimitBytes: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "bandwidthLimitBytes",
+				Help:        "Limit of bytes in bandwidth to use in the last 30 days",
+				ConstLabels: nil,
+			},
+		),
+		bandwidthUsageRatio: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "bandwidthUsageRatio",
+				Help:        "Ratio of used bytes in bandwidth over corresponding limit",
+				ConstLabels: nil,
+			},
+		),
+		storageUsageBytes: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "storageUsageBytes",
+				Help:        "Bytes of storage used in the last 30 days",
+				ConstLabels: nil,
+			},
+		),
+		storageLimitBytes: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "storageLimitBytes",
+				Help:        "Limit of storage used allowed in the last 30 days",
+				ConstLabels: nil,
+			},
+		),
+		storageUsageRatio: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "storageUsageRatio",
+				Help:        "Ratio of storage bytes used over corresponding limit",
+				ConstLabels: nil,
+			},
+		),
+		requestsAmount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "requestsAmount",
+				Help:        "Number of requests done to Cloudinary",
+				ConstLabels: nil,
+			},
+		),
+		resourcesAmount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "resourcesAmount",
+				Help:        "Number of resources in Cloudinary",
+				ConstLabels: nil,
+			},
+		),
+		derivedResourcesAmount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   "cloudinary",
+				Name:        "derivedResourcesAmount",
+				Help:        "Number of derived resources in Cloudinary",
+				ConstLabels: nil,
+			},
+		),
+	}
+}
+
+// Describe is a requirement for the Collector interface of Prometheus
+// that returns each exported metric's description to the Prometheus
+// middleware
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.transformationsUsageAmount.Describe(ch)
+	c.transformationsLimitAmount.Describe(ch)
+	c.transformationsUsageRatio.Describe(ch)
+	c.objectsUsageAmount.Describe(ch)
+	c.objectsLimitAmount.Describe(ch)
+	c.objectsUsageRatio.Describe(ch)
+	c.bandwidthUsageBytes.Describe(ch)
+	c.bandwidthLimitBytes.Describe(ch)
+	c.bandwidthUsageRatio.Describe(ch)
+	c.storageUsageBytes.Describe(ch)
+	c.storageLimitBytes.Describe(ch)
+	c.storageUsageRatio.Describe(ch)
+	c.requestsAmount.Describe(ch)
+	c.resourcesAmount.Describe(ch)
+	c.derivedResourcesAmount.Describe(ch)
+}
+
+// Collect is a requirement for the Collector interface of Prometheus
+// that runs the queries to set the metrics values to be exported
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.runCollection()
+
+	c.transformationsUsageAmount.Collect(ch)
+	c.transformationsLimitAmount.Collect(ch)
+	c.transformationsUsageRatio.Collect(ch)
+	c.objectsUsageAmount.Collect(ch)
+	c.objectsLimitAmount.Collect(ch)
+	c.objectsUsageRatio.Collect(ch)
+	c.bandwidthUsageBytes.Collect(ch)
+	c.bandwidthLimitBytes.Collect(ch)
+	c.bandwidthUsageRatio.Collect(ch)
+	c.storageUsageBytes.Collect(ch)
+	c.storageLimitBytes.Collect(ch)
+	c.storageUsageRatio.Collect(ch)
+	c.requestsAmount.Collect(ch)
+	c.resourcesAmount.Collect(ch)
+	c.derivedResourcesAmount.Collect(ch)
+}
+
+func (c *Collector) runCollection() {
+	cloudName, key, secret := CloudinaryCredentials.get()
+	report, err := getUsageReport(
+		fmt.Sprintf(
+			"https://%s:%s@api.cloudinary.com/v1_1/%s/usage",
+			key,
+			secret,
+			cloudName,
+		),
+	)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	c.transformationsUsageAmount.Set(transformationUsage(*report))
+	c.transformationsLimitAmount.Set(transformationLimit(*report))
+	c.transformationsUsageRatio.Set(transformationsUsageRatio(*report))
+	c.objectsUsageAmount.Set(objectsUsage(*report))
+	c.objectsLimitAmount.Set(objectsLimit(*report))
+	c.objectsUsageRatio.Set(objectsUsageRatio(*report))
+	c.bandwidthUsageBytes.Set(bandwidthUsage(*report))
+	c.bandwidthLimitBytes.Set(bandwidthLimit(*report))
+	c.bandwidthUsageRatio.Set(bandwidthUsageRatio(*report))
+	c.storageUsageBytes.Set(storageUsage(*report))
+	c.storageLimitBytes.Set(storageLimit(*report))
+	c.storageUsageRatio.Set(storageUsageRatio(*report))
+	c.requestsAmount.Set(requests(*report))
+	c.resourcesAmount.Set(resources(*report))
+	c.derivedResourcesAmount.Set(derivedResources(*report))
+}

--- a/pkg/cloudinary/credentials.go
+++ b/pkg/cloudinary/credentials.go
@@ -1,0 +1,29 @@
+package cloudinary
+
+import (
+	"errors"
+)
+
+var CloudinaryCredentials *Credentials
+
+type Credentials struct {
+	cloudName string
+	key       string
+	secret    string
+}
+
+func NewCredentials(cloudName, key, secret string) error {
+	if key == "" || secret == "" || cloudName == "" {
+		return errors.New("No credentials defined")
+	}
+	CloudinaryCredentials = &Credentials{
+		cloudName: cloudName,
+		key:       key,
+		secret:    secret,
+	}
+	return nil
+}
+
+func (c *Credentials) get() (string, string, string) {
+	return c.cloudName, c.key, c.secret
+}

--- a/pkg/cloudinary/credentials.go
+++ b/pkg/cloudinary/credentials.go
@@ -4,14 +4,18 @@ import (
 	"errors"
 )
 
+// CloudinaryCredentials is the global variable for the Cloudinary's account's
+// credentials.
 var CloudinaryCredentials *Credentials
 
+// Credentials represents a set of Cloudinary credentials.
 type Credentials struct {
 	cloudName string
 	key       string
 	secret    string
 }
 
+// NewCredentials creates the Credentials object.
 func NewCredentials(cloudName, key, secret string) error {
 	if key == "" || secret == "" || cloudName == "" {
 		return errors.New("No credentials defined")

--- a/pkg/cloudinary/usage_report.go
+++ b/pkg/cloudinary/usage_report.go
@@ -7,12 +7,16 @@ import (
 	"net/http"
 )
 
+// UsageInfo represents the three different metrics for Transformations,
+// Object, Bandwidth, and Storage.
 type UsageInfo struct {
 	Usage       int64   `json:"usage"`
 	Limit       int64   `json:"limit"`
 	UsedPercent float64 `json:"used_percent"`
 }
 
+// UsageReport represents the response from Cloudinary's Admin API on
+// usage report.
 type UsageReport struct {
 	Plan             string    `json:"plan"`
 	LastUpdate       string    `json:"last_updated"`
@@ -25,24 +29,8 @@ type UsageReport struct {
 	DerivedResources int64     `json:"derived_resources"`
 }
 
-func GetRequest() (req *http.Request, err error) {
-	cloudName, key, secret := CloudinaryCredentials.get()
-	req, err = http.NewRequest(
-		"GET",
-		fmt.Sprintf(
-			"https://%s:%s@api.cloudinary.com/v1_1/%s/usage",
-			key,
-			secret,
-			cloudName,
-		),
-		nil,
-	)
-	return req, err
-}
-
-func GetUsageReport(req *http.Request) (usageReport *UsageReport, err error) {
-	client := http.Client{}
-	rs, err := client.Do(req)
+func getUsageReport(url string) (usageReport *UsageReport, err error) {
+	rs, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"ERROR: Request failure: %v",
@@ -67,62 +55,62 @@ func GetUsageReport(req *http.Request) (usageReport *UsageReport, err error) {
 	return usageReport, err
 }
 
-func DerivedResources(usageReport UsageReport) float64 {
+func derivedResources(usageReport UsageReport) float64 {
 	return float64(usageReport.DerivedResources)
 }
 
-func Resources(usageReport UsageReport) float64 {
+func resources(usageReport UsageReport) float64 {
 	return float64(usageReport.Resources)
 }
 
-func Requests(usageReport UsageReport) float64 {
+func requests(usageReport UsageReport) float64 {
 	return float64(usageReport.Requests)
 }
 
-func StorageUsage(usageReport UsageReport) float64 {
+func storageUsage(usageReport UsageReport) float64 {
 	return float64(usageReport.Storage.Usage)
 }
 
-func StorageLimit(usageReport UsageReport) float64 {
+func storageLimit(usageReport UsageReport) float64 {
 	return float64(usageReport.Storage.Limit)
 }
 
-func StorageUsageRatio(usageReport UsageReport) float64 {
+func storageUsageRatio(usageReport UsageReport) float64 {
 	return float64(usageReport.Storage.UsedPercent / 100)
 }
 
-func BandwidthUsage(usageReport UsageReport) float64 {
+func bandwidthUsage(usageReport UsageReport) float64 {
 	return float64(usageReport.Bandwidth.Usage)
 }
 
-func BandwidthLimit(usageReport UsageReport) float64 {
+func bandwidthLimit(usageReport UsageReport) float64 {
 	return float64(usageReport.Bandwidth.Limit)
 }
 
-func BandwidthUsageRatio(usageReport UsageReport) float64 {
+func bandwidthUsageRatio(usageReport UsageReport) float64 {
 	return float64(usageReport.Bandwidth.UsedPercent / 100)
 }
 
-func ObjectsUsage(usageReport UsageReport) float64 {
+func objectsUsage(usageReport UsageReport) float64 {
 	return float64(usageReport.Objects.Usage)
 }
 
-func ObjectsLimit(usageReport UsageReport) float64 {
+func objectsLimit(usageReport UsageReport) float64 {
 	return float64(usageReport.Objects.Limit)
 }
 
-func ObjectsUsageRatio(usageReport UsageReport) float64 {
+func objectsUsageRatio(usageReport UsageReport) float64 {
 	return float64(usageReport.Objects.UsedPercent / 100)
 }
 
-func TransformationUsage(usageReport UsageReport) float64 {
+func transformationUsage(usageReport UsageReport) float64 {
 	return float64(usageReport.Transformations.Usage)
 }
 
-func TransformationLimit(usageReport UsageReport) float64 {
+func transformationLimit(usageReport UsageReport) float64 {
 	return float64(usageReport.Transformations.Limit)
 }
 
-func TransformationUsageRatio(usageReport UsageReport) float64 {
+func transformationUsageRatio(usageReport UsageReport) float64 {
 	return float64(usageReport.Transformations.UsedPercent / 100)
 }

--- a/pkg/cloudinary/usage_report.go
+++ b/pkg/cloudinary/usage_report.go
@@ -1,0 +1,128 @@
+package cloudinary
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type UsageInfo struct {
+	Usage       int64   `json:"usage"`
+	Limit       int64   `json:"limit"`
+	UsedPercent float64 `json:"used_percent"`
+}
+
+type UsageReport struct {
+	Plan             string    `json:"plan"`
+	LastUpdate       string    `json:"last_updated"`
+	Transformations  UsageInfo `json:"transformations"`
+	Objects          UsageInfo `json:"objects"`
+	Bandwidth        UsageInfo `json:"bandwidth"`
+	Storage          UsageInfo `json:"storage"`
+	Requests         int64     `json:"requests"`
+	Resources        int64     `json:"resources"`
+	DerivedResources int64     `json:"derived_resources"`
+}
+
+func GetRequest() (req *http.Request, err error) {
+	cloudName, key, secret := CloudinaryCredentials.get()
+	req, err = http.NewRequest(
+		"GET",
+		fmt.Sprintf(
+			"https://%s:%s@api.cloudinary.com/v1_1/%s/usage",
+			key,
+			secret,
+			cloudName,
+		),
+		nil,
+	)
+	return req, err
+}
+
+func GetUsageReport(req *http.Request) (usageReport *UsageReport, err error) {
+	client := http.Client{}
+	rs, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"ERROR: Request failure: %v",
+			err,
+		)
+	}
+	defer rs.Body.Close()
+
+	if rs.StatusCode != 200 && rs.StatusCode != 201 {
+		return nil, fmt.Errorf(
+			"ERROR: Cloudinary API complained: %v",
+			rs.Header.Get("X-Cld-Error"),
+		)
+	}
+	bodyBytes, err := ioutil.ReadAll(rs.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	usageReport = new(UsageReport)
+	err = json.Unmarshal(bodyBytes, &usageReport)
+	return usageReport, err
+}
+
+func DerivedResources(usageReport UsageReport) float64 {
+	return float64(usageReport.DerivedResources)
+}
+
+func Resources(usageReport UsageReport) float64 {
+	return float64(usageReport.Resources)
+}
+
+func Requests(usageReport UsageReport) float64 {
+	return float64(usageReport.Requests)
+}
+
+func StorageUsage(usageReport UsageReport) float64 {
+	return float64(usageReport.Storage.Usage)
+}
+
+func StorageLimit(usageReport UsageReport) float64 {
+	return float64(usageReport.Storage.Limit)
+}
+
+func StorageUsageRatio(usageReport UsageReport) float64 {
+	return float64(usageReport.Storage.UsedPercent / 100)
+}
+
+func BandwidthUsage(usageReport UsageReport) float64 {
+	return float64(usageReport.Bandwidth.Usage)
+}
+
+func BandwidthLimit(usageReport UsageReport) float64 {
+	return float64(usageReport.Bandwidth.Limit)
+}
+
+func BandwidthUsageRatio(usageReport UsageReport) float64 {
+	return float64(usageReport.Bandwidth.UsedPercent / 100)
+}
+
+func ObjectsUsage(usageReport UsageReport) float64 {
+	return float64(usageReport.Objects.Usage)
+}
+
+func ObjectsLimit(usageReport UsageReport) float64 {
+	return float64(usageReport.Objects.Limit)
+}
+
+func ObjectsUsageRatio(usageReport UsageReport) float64 {
+	return float64(usageReport.Objects.UsedPercent / 100)
+}
+
+func TransformationUsage(usageReport UsageReport) float64 {
+	return float64(usageReport.Transformations.Usage)
+}
+
+func TransformationLimit(usageReport UsageReport) float64 {
+	return float64(usageReport.Transformations.Limit)
+}
+
+func TransformationUsageRatio(usageReport UsageReport) float64 {
+	return float64(usageReport.Transformations.UsedPercent / 100)
+}


### PR DESCRIPTION
This adds the `cloudinary` package from
[cloudinary_exporter](https://github.com/ifosch/cloudinary_exporter). The
cloudinary_exporter is the one currently used to get usage metrics from
cloudinary, but it is faulty due to how the Cloudinary's Admin API behaves.
To fix that, this exporter is going to be replaced with a collector,
written as a dextre subcommand, which will send metrics to Push Gateway.

This subcommand requests the Cloudinary's Admin API, using credentials
provided through environment variables, and pushes the metrics collected to
the Push Gateway specified by `--push-gateway` CLI argument.

Refs [DVX-7220](https://mydevex.atlassian.net/browse/DVX-7220)