### PR TITLE
DVX-7420 Add robots.txt golden copy generate command to dextre

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -272,6 +272,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "607effde0b4c87d796a9a79448b5c3f2966ed81694df4e36f5245ec059c6c123"
+  inputs-digest = "5c2fa0666e9b9fec45c01bdeeed4995d6c0e8b22ed73e89920a6aafea223ea5e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/capcom/cmd/add.go
+++ b/cmd/capcom/cmd/add.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/capcom"
+	"github.com/Devex/spaceflight/pkg/capcom"
 )
 
 var source, proto string

--- a/cmd/capcom/cmd/create.go
+++ b/cmd/capcom/cmd/create.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/capcom"
+	"github.com/Devex/spaceflight/pkg/capcom"
 )
 
 var name, vpcid string

--- a/cmd/capcom/cmd/list.go
+++ b/cmd/capcom/cmd/list.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/capcom"
+	"github.com/Devex/spaceflight/pkg/capcom"
 )
 
 var graph, search bool

--- a/cmd/capcom/cmd/revoke.go
+++ b/cmd/capcom/cmd/revoke.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/capcom"
+	"github.com/Devex/spaceflight/pkg/capcom"
 )
 
 // revokeCmd represents the revoke command

--- a/cmd/capcom/main.go
+++ b/cmd/capcom/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/poka-yoke/spaceflight/cmd/capcom/cmd"
+import "github.com/Devex/spaceflight/cmd/capcom/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/devex_exporter/main.go
+++ b/cmd/devex_exporter/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/poka-yoke/spaceflight/pkg/dnsbl"
+	"github.com/Devex/spaceflight/pkg/dnsbl"
 )
 
 func main() {

--- a/cmd/dextre/cmd/bl.go
+++ b/cmd/dextre/cmd/bl.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/dnsbl"
+	"github.com/Devex/spaceflight/pkg/dnsbl"
 )
 
 func must(err error) {

--- a/cmd/dextre/cmd/cloudinary.go
+++ b/cmd/dextre/cmd/cloudinary.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/cloudinary"
+	"github.com/Devex/spaceflight/pkg/cloudinary"
 )
 
 // cloudinaryCmd represents the cloudinary command

--- a/cmd/dextre/cmd/robots.go
+++ b/cmd/dextre/cmd/robots.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var goldenFile string
+
+// RobotsCmd represents the robots command
+var RobotsCmd = &cobra.Command{
+	Use:   "robots",
+	Short: "Monitor published robots.txt",
+	Long: `Helps with robots.txt monitoring, detecting changes from a
+golden file, that needs to be generated.`,
+}
+
+func init() {
+	RootCmd.AddCommand(RobotsCmd)
+}

--- a/cmd/dextre/cmd/robots_generate_golden.go
+++ b/cmd/dextre/cmd/robots_generate_golden.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// robotsGenGCmd represents the robots gen_gc command
+var robotsGenGCmd = &cobra.Command{
+	Use:   "generate-golden",
+	Short: "Get golden file for robots check",
+	Long: `Gets the specified URL contents and stores it as a golden file
+for subsequent robots checks.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if goldenFile == "" {
+			log.Fatal("Golden file is mandatory")
+		}
+		if len(args) < 1 {
+			log.Fatal("No URL specified")
+		}
+		url := args[0]
+
+		if _, err := os.Stat(goldenFile); err == nil {
+			log.Fatalf("Golden file %s already exists", goldenFile)
+		}
+
+		resp, err := http.Get(url)
+		if err != nil {
+			log.Fatalf("Failed to get URL %s: %s", url, err)
+		}
+		defer resp.Body.Close()
+
+		out, err := os.Create(goldenFile)
+		if err != nil {
+			log.Fatalf(
+				"Failed to create golden file %s: %s",
+				goldenFile,
+				err,
+			)
+		}
+		defer out.Close()
+
+		_, err = io.Copy(out, resp.Body)
+		if err != nil {
+			log.Fatalf(
+				"Failed to copy data from %s to %s: %s",
+				url,
+				goldenFile,
+				err,
+			)
+		}
+	},
+}
+
+func init() {
+	RobotsCmd.AddCommand(robotsGenGCmd)
+
+	robotsGenGCmd.Flags().StringVarP(
+		&goldenFile,
+		"golden-file",
+		"g",
+		"",
+		"File name for the Golden File.",
+	)
+}

--- a/cmd/dextre/cmd/sidekiq.go
+++ b/cmd/dextre/cmd/sidekiq.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/sidekiq"
+	"github.com/Devex/spaceflight/pkg/sidekiq"
 )
 
 var baseURL string

--- a/cmd/dextre/cmd/sitemap.go
+++ b/cmd/dextre/cmd/sitemap.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/sitemap"
+	"github.com/Devex/spaceflight/pkg/sitemap"
 )
 
 var url, file string

--- a/cmd/dextre/main.go
+++ b/cmd/dextre/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/poka-yoke/spaceflight/cmd/dextre/cmd"
+import "github.com/Devex/spaceflight/cmd/dextre/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/fido/cmd/get.go
+++ b/cmd/fido/cmd/get.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/fido"
+	"github.com/Devex/spaceflight/pkg/fido"
 )
 
 var name string

--- a/cmd/fido/cmd/json.go
+++ b/cmd/fido/cmd/json.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/fido"
+	"github.com/Devex/spaceflight/pkg/fido"
 )
 
 // jsonCmd represents the json command

--- a/cmd/fido/cmd/push.go
+++ b/cmd/fido/cmd/push.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/fido"
+	"github.com/Devex/spaceflight/pkg/fido"
 )
 
 var file string

--- a/cmd/fido/main.go
+++ b/cmd/fido/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/poka-yoke/spaceflight/cmd/fido/cmd"
+import "github.com/Devex/spaceflight/cmd/fido/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/got/cmd/delete.go
+++ b/cmd/got/cmd/delete.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/got"
+	"github.com/Devex/spaceflight/pkg/got"
 )
 
 // deleteCmd represents the delete command

--- a/cmd/got/cmd/ttl.go
+++ b/cmd/got/cmd/ttl.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/got"
+	"github.com/Devex/spaceflight/pkg/got"
 )
 
 var dryrun, exclude, wait, filterByName, filterByType bool

--- a/cmd/got/cmd/upsert.go
+++ b/cmd/got/cmd/upsert.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/got"
+	"github.com/Devex/spaceflight/pkg/got"
 )
 
 var name, typ string

--- a/cmd/got/main.go
+++ b/cmd/got/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/poka-yoke/spaceflight/cmd/got/cmd"
+import "github.com/Devex/spaceflight/cmd/got/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/health/cmd/create.go
+++ b/cmd/health/cmd/create.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/cronitor"
-	"github.com/poka-yoke/spaceflight/pkg/health"
+	"github.com/Devex/spaceflight/pkg/cronitor"
+	"github.com/Devex/spaceflight/pkg/health"
 )
 
 // Check is an interface to be implemented by all backend providers

--- a/cmd/health/main.go
+++ b/cmd/health/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/poka-yoke/spaceflight/cmd/health/cmd"
+import "github.com/Devex/spaceflight/cmd/health/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/odin/cmd/instance_clone.go
+++ b/cmd/odin/cmd/instance_clone.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 var from string

--- a/cmd/odin/cmd/instance_create.go
+++ b/cmd/odin/cmd/instance_create.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 var instanceType, password, user, subnetName, securityGroups string

--- a/cmd/odin/cmd/instance_delete.go
+++ b/cmd/odin/cmd/instance_delete.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 var finalSnapshotID string

--- a/cmd/odin/cmd/instance_restore.go
+++ b/cmd/odin/cmd/instance_restore.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 // instanceRestoreCmd represents the instance restore command

--- a/cmd/odin/cmd/instance_scale.go
+++ b/cmd/odin/cmd/instance_scale.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 var delay bool

--- a/cmd/odin/cmd/snapshot_create.go
+++ b/cmd/odin/cmd/snapshot_create.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 // snapshotCreateCmd represents the snapshot create command

--- a/cmd/odin/cmd/snapshot_list.go
+++ b/cmd/odin/cmd/snapshot_list.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 // snapshotListCmd represents the snapshot list command

--- a/cmd/odin/main.go
+++ b/cmd/odin/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/poka-yoke/spaceflight/cmd/odin/cmd"
+import "github.com/Devex/spaceflight/cmd/odin/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/roosa/main.go
+++ b/cmd/roosa/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
 
-	"github.com/poka-yoke/spaceflight/pkg/roosa"
+	"github.com/Devex/spaceflight/pkg/roosa"
 )
 
 var zoneName string

--- a/cmd/short/cmd/add.go
+++ b/cmd/short/cmd/add.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/short"
+	"github.com/Devex/spaceflight/pkg/short"
 )
 
 var apiKey, addURL string

--- a/cmd/short/cmd/update.go
+++ b/cmd/short/cmd/update.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/short"
+	"github.com/Devex/spaceflight/pkg/short"
 )
 
 // updateCmd represents the update command

--- a/cmd/short/main.go
+++ b/cmd/short/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/poka-yoke/spaceflight/cmd/short/cmd"
+import "github.com/Devex/spaceflight/cmd/short/cmd"
 
 func main() {
 	cmd.Execute()

--- a/cmd/surgeon/main.go
+++ b/cmd/surgeon/main.go
@@ -9,7 +9,7 @@ import (
 
 	_ "github.com/lib/pq"
 
-	"github.com/poka-yoke/spaceflight/pkg/surgeon"
+	"github.com/Devex/spaceflight/pkg/surgeon"
 )
 
 // GetDB returns a sql.DB object to be used when running queries.

--- a/cmd/trek/cmd/add.go
+++ b/cmd/trek/cmd/add.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/poka-yoke/spaceflight/pkg/trek"
+	"github.com/Devex/spaceflight/pkg/trek"
 )
 
 var original, final string

--- a/cmd/trek/main.go
+++ b/cmd/trek/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/poka-yoke/spaceflight/cmd/trek/cmd"
+import "github.com/Devex/spaceflight/cmd/trek/cmd"
 
 func main() {
 	cmd.Execute()

--- a/pkg/got/got.go
+++ b/pkg/got/got.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 
-	"github.com/poka-yoke/spaceflight/pkg/internal/http"
+	"github.com/Devex/spaceflight/pkg/internal/http"
 )
 
 // Verbose flag

--- a/pkg/odin/instance_clone_test.go
+++ b/pkg/odin/instance_clone_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/rds"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 type cloneInstanceCase struct {

--- a/pkg/odin/instance_create_test.go
+++ b/pkg/odin/instance_create_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 type createInstanceCase struct {

--- a/pkg/odin/instance_delete_test.go
+++ b/pkg/odin/instance_delete_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 type deleteInstanceCase struct {

--- a/pkg/odin/instance_restore_test.go
+++ b/pkg/odin/instance_restore_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 type getRestoreDBInputCase struct {

--- a/pkg/odin/instance_scale_test.go
+++ b/pkg/odin/instance_scale_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 type scaleInstanceCase struct {

--- a/pkg/odin/odin_test.go
+++ b/pkg/odin/odin_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/go-test/deep"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 type testCase struct {

--- a/pkg/odin/snapshot_create_test.go
+++ b/pkg/odin/snapshot_create_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 type createSnapshotsCase struct {

--- a/pkg/odin/snapshot_list_test.go
+++ b/pkg/odin/snapshot_list_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 
-	"github.com/poka-yoke/spaceflight/pkg/odin"
+	"github.com/Devex/spaceflight/pkg/odin"
 )
 
 var exampleSnapshot1Type = aws.String("db.m1.medium")


### PR DESCRIPTION
This adds a new command with a subcommand to dextre to create a golden copy from
a URL. Usage:
```
dextre robots gen_gc -g <destination file> <origin url>
```

This golden copy will be used by another `robots` subcommand to check the URL
has not changed.

This also fix import paths to use Devex fork locations in all other projects.

Refs [DVX-7420](https://mydevex.atlassian.net/browse/DVX-7420)