### PR TITLE
DVX-7420 Add robots check subcommand to dextre

### DIFF
--- a/cmd/dextre/cmd/bl.go
+++ b/cmd/dextre/cmd/bl.go
@@ -12,12 +12,6 @@ import (
 	"github.com/Devex/spaceflight/pkg/dnsbl"
 )
 
-func must(err error) {
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
 var ipAddress, blacklist, pgaddress string
 var warning, critical int
 

--- a/cmd/dextre/cmd/common.go
+++ b/cmd/dextre/cmd/common.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+)
+
+func must(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func checkGoldenFile() error {
+	if goldenFile == "" {
+		return fmt.Errorf("Golden file is mandatory")
+	}
+	return nil
+}
+
+func checkURL(args []string) string {
+	if len(args) < 1 {
+		log.Fatalf("No URL specified")
+	}
+	return args[0]
+}
+
+func checkPGAddress() error {
+	if pgaddress == "" {
+		return fmt.Errorf("Push Gateway address is mandatory")
+	}
+	return nil
+}

--- a/cmd/dextre/cmd/robots_check.go
+++ b/cmd/dextre/cmd/robots_check.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"log"
+	"os"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
+	"github.com/spf13/cobra"
+
+	"github.com/Devex/spaceflight/internal/digest"
+	"github.com/Devex/spaceflight/internal/http"
+)
+
+var robotsState = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name: "robots_txt_state",
+	Help: `The state of the robots.txt comparison to the golden
+file. 0 means equal, 1, different`,
+})
+
+// robotsCheckCmd represents the robots check command
+var robotsCheckCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Checks differences between a URL and a golden file",
+	Long: `Checks differences between a URL and a golden file.
+The golden file can be generated using the gen_gc command`,
+	Run: func(cmd *cobra.Command, args []string) {
+		must(checkPGAddress())
+		must(checkGoldenFile())
+		url := checkURL(args)
+
+		resp := http.Get(url)
+		defer resp.Body.Close()
+
+		body, err := digest.ContentBase64(resp.Body)
+		if err != nil {
+			log.Fatalf("Failed to hash downloaded content: %s", err)
+		}
+
+		in, err := os.Open(goldenFile)
+		if err != nil {
+			log.Fatalf(
+				"Failed to read %s: %s",
+				goldenFile,
+				err,
+			)
+		}
+		defer in.Close()
+
+		golden, err := digest.ContentBase64(in)
+		if err != nil {
+			log.Fatalf("Failed to hash golden file: %s", err)
+		}
+
+		pusher := push.New(pgaddress, "robots").
+			Collector(robotsState).
+			Grouping("web", strings.Split(url, "/")[2])
+
+		if body != golden {
+			robotsState.Set(1)
+			log.Printf(
+				"Hashes are different! Expected %s but got %s",
+				golden,
+				body,
+			)
+		} else {
+			robotsState.Set(0)
+			log.Printf("Hashes are equal")
+		}
+
+		if err := pusher.Push(); err != nil {
+			log.Fatalf("Could not push to Push Gateway: %v", err)
+		}
+	},
+}
+
+func init() {
+	RobotsCmd.AddCommand(robotsCheckCmd)
+
+	robotsCheckCmd.Flags().StringVarP(
+		&goldenFile,
+		"golden-file",
+		"g",
+		"",
+		"File name for the Golden file.",
+	)
+
+	robotsCheckCmd.Flags().StringVarP(
+		&pgaddress,
+		"push-gateway",
+		"p",
+		"",
+		"Address of the Prometheus PushGateway to send results to.",
+	)
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -1,4 +1,4 @@
-package digests
+package digest
 
 import (
 	"crypto/sha1"

--- a/internal/http/get.go
+++ b/internal/http/get.go
@@ -1,0 +1,15 @@
+package http
+
+import (
+	"log"
+	"net/http"
+)
+
+// Get does http.Get, but catching and logging errors arising.
+func Get(url string) *http.Response {
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Fatalf("Failed to get URL %s: %s", url, err)
+	}
+	return resp
+}

--- a/internal/utils/digests.go
+++ b/internal/utils/digests.go
@@ -1,0 +1,17 @@
+package digests
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"io"
+)
+
+// ContentBase64 is providing a Base64 encoded SHA1 hash from a io.Reader.
+func ContentBase64(input io.Reader) (encoded string, err error) {
+	hasher := sha1.New()
+	if _, err = io.Copy(hasher, input); err != nil {
+		return "", err
+	}
+	encoded = base64.StdEncoding.EncodeToString(hasher.Sum(nil))
+	return encoded, nil
+}


### PR DESCRIPTION
This subcommand will check the specified URL content is matching the
specified golden file and pushes the result (0 if matching, 1 otherwise),
to Push Gateway.

This change also adds some useful functions to check required arguments are
present, and to get the content from the URL.

This adds a function to get Base64 digest of a io.Reader so it can be
quickly compared to other ones. This function is using SHA1 for the digest.


Refs [DVX-7420](https://mydevex.atlassian.net/browse/DVX-7420)