### PR TITLE
DVX-7420 Extend usage of checkPGAddress and must to dextre cmds

### DIFF
--- a/cmd/dextre/cmd/cloudinary.go
+++ b/cmd/dextre/cmd/cloudinary.go
@@ -22,9 +22,7 @@ var cloudinaryCmd = &cobra.Command{
 			os.Getenv("CLOUDINARY_SECRET"),
 		))
 
-		if pgaddress == "" {
-			log.Fatal("pgaddress is mandatory")
-		}
+		must(checkPGAddress())
 		err := push.New(pgaddress, "cloudinary").
 			Collector(cloudinary.NewCollector()).Push()
 

--- a/cmd/dextre/cmd/robots_generate_golden.go
+++ b/cmd/dextre/cmd/robots_generate_golden.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"io"
 	"log"
-	"net/http"
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/Devex/spaceflight/internal/http"
 )
 
 // robotsGenGCmd represents the robots gen_gc command
@@ -16,22 +17,15 @@ var robotsGenGCmd = &cobra.Command{
 	Long: `Gets the specified URL contents and stores it as a golden file
 for subsequent robots checks.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if goldenFile == "" {
-			log.Fatal("Golden file is mandatory")
-		}
-		if len(args) < 1 {
-			log.Fatal("No URL specified")
-		}
-		url := args[0]
+		must(checkPGAddress())
+		must(checkGoldenFile())
+		url := checkURL(args)
 
 		if _, err := os.Stat(goldenFile); err == nil {
 			log.Fatalf("Golden file %s already exists", goldenFile)
 		}
 
-		resp, err := http.Get(url)
-		if err != nil {
-			log.Fatalf("Failed to get URL %s: %s", url, err)
-		}
+		resp := http.Get(url)
 		defer resp.Body.Close()
 
 		out, err := os.Create(goldenFile)

--- a/cmd/dextre/cmd/sitemap.go
+++ b/cmd/dextre/cmd/sitemap.go
@@ -21,9 +21,7 @@ var sitemapCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var urls []string
 
-		if pgaddress == "" {
-			log.Fatal("pgaddress is mandatory")
-		}
+		must(checkPGAddress())
 		if url == "" && file == "" {
 			log.Fatal("Either URL or file are mandatory")
 		}


### PR DESCRIPTION
This makes other dextre subcommands to make use of checkPGAddress and must.

Refs [DVX-7420](https://mydevex.atlassian.net/browse/DVX-7420)